### PR TITLE
Issue Fix #60

### DIFF
--- a/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
@@ -897,19 +897,29 @@ namespace Bricelam.EntityFrameworkCore.Design
             var lastSpaceIndex = word.LastIndexOf(' ');
             prefixWord = word.Substring(0, lastSpaceIndex + 1);
 
+            // Check if the prefix is empty (empty prefix means, the suffix could not be extracted from the string by splitting it by space)
             if (!string.IsNullOrWhiteSpace(prefixWord))
             {
+                // Return the suffix 
                 return word.Substring(lastSpaceIndex + 1);
             }
-            // Use the last capital letter to separate the suffix word
+
+            // UPPER CASE SPLIT TO EXTRACT SUFFIX
+            // Check if there are any upper case characters in the string
             if (word.Any(x => char.IsUpper(x)))
             {
-                var lastUpperCaseLetter = word.Reverse().First(x => char.IsUpper(x));
-                var lastUpperCaseIndex = word.LastIndexOf(lastUpperCaseLetter);
+                // Get the lastly occuring Upper Case character in the string
+                var lastUpperCaseChar = word.Reverse().First(x => char.IsUpper(x));
+                // Get the index of the lastly occuring upper case character in the string
+                var lastUpperCaseIndex = word.LastIndexOf(lastUpperCaseChar);
+                // Get the prefix word spliting the string at the index of the lastly occuring Upper case charater in the string
                 prefixWord = word.Substring(0, lastUpperCaseIndex);
+
+                // Return the suffix word 
                 return word.Substring(lastUpperCaseIndex);
             }
-            //prefixWord = word.Reverse().
+            
+            // Return the word itself as the suffix word if a suffix cannot be extracted
             return word;
         }
 

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
@@ -295,7 +295,7 @@ namespace Bricelam.EntityFrameworkCore.Design
             { "sinus", "sinus" },
             { "coitus", "coitus" },
             { "plexus", "plexus" },
-            { "status", "status" },
+            //{ "status", "status" },
             { "hiatus", "hiatus" },
             { "afreet", "afreeti" },
             { "afrit", "afriti" },
@@ -601,7 +601,7 @@ namespace Bricelam.EntityFrameworkCore.Design
             // [cs]h and ss that take es as plural form
             if (TryInflectOnSuffixInWord(
                 suffixWord,
-                new[] { "ch", "sh", "ss" },
+                new[] { "ch", "sh", "ss", "us" },
                 (s) => s + "es",
                 out newSuffixWord))
             {
@@ -897,8 +897,20 @@ namespace Bricelam.EntityFrameworkCore.Design
             var lastSpaceIndex = word.LastIndexOf(' ');
             prefixWord = word.Substring(0, lastSpaceIndex + 1);
 
-            // CONSIDER(leil): use capital letters to separate the words
-            return word.Substring(lastSpaceIndex + 1);
+            if (!string.IsNullOrWhiteSpace(prefixWord))
+            {
+                return word.Substring(lastSpaceIndex + 1);
+            }
+            // Use the last capital letter to separate the suffix word
+            if (word.Any(x => char.IsUpper(x)))
+            {
+                var lastUpperCaseLetter = word.Reverse().First(x => char.IsUpper(x));
+                var lastUpperCaseIndex = word.LastIndexOf(lastUpperCaseLetter);
+                prefixWord = word.Substring(0, lastUpperCaseIndex);
+                return word.Substring(lastUpperCaseIndex);
+            }
+            //prefixWord = word.Reverse().
+            return word;
         }
 
         static bool IsCapitalized(string word)

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
@@ -295,7 +295,7 @@ namespace Bricelam.EntityFrameworkCore.Design
             { "sinus", "sinus" },
             { "coitus", "coitus" },
             { "plexus", "plexus" },
-            //{ "status", "status" },
+            //{ "status", "status" }, // Commented out because it is setting "status" as a plural word
             { "hiatus", "hiatus" },
             { "afreet", "afreeti" },
             { "afrit", "afriti" },

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/Pluralizer.cs
@@ -295,7 +295,6 @@ namespace Bricelam.EntityFrameworkCore.Design
             { "sinus", "sinus" },
             { "coitus", "coitus" },
             { "plexus", "plexus" },
-            //{ "status", "status" }, // Commented out because it is setting "status" as a plural word
             { "hiatus", "hiatus" },
             { "afreet", "afreeti" },
             { "afrit", "afriti" },
@@ -893,36 +892,39 @@ namespace Bricelam.EntityFrameworkCore.Design
         // separate one combine word in to two parts, prefix word and the last word(suffix word)
         static string GetSuffixWord(string word, out string prefixWord)
         {
-            // use the last space to separate the words
+            var suffix = ExtractSuffixByLastSpace(word, out string firstPrefixWord);
+
+            suffix = ExtractSuffixByLastUpperCase(suffix, out string secondPrefixWord);
+
+            prefixWord = firstPrefixWord + secondPrefixWord;
+
+            return suffix;
+        }
+
+        static string ExtractSuffixByLastSpace(string word, out string prefixWord)
+        {
             var lastSpaceIndex = word.LastIndexOf(' ');
             prefixWord = word.Substring(0, lastSpaceIndex + 1);
 
-            // Check if the prefix is empty (empty prefix means, the suffix could not be extracted from the string by splitting it by space)
-            if (!string.IsNullOrWhiteSpace(prefixWord))
-            {
-                // Return the suffix 
-                return word.Substring(lastSpaceIndex + 1);
-            }
-
-            // UPPER CASE SPLIT TO EXTRACT SUFFIX
-            // Check if there are any upper case characters in the string
-            if (word.Any(x => char.IsUpper(x)))
-            {
-                // Get the lastly occuring Upper Case character in the string
-                var lastUpperCaseChar = word.Reverse().First(x => char.IsUpper(x));
-                // Get the index of the lastly occuring upper case character in the string
-                var lastUpperCaseIndex = word.LastIndexOf(lastUpperCaseChar);
-                // Get the prefix word spliting the string at the index of the lastly occuring Upper case charater in the string
-                prefixWord = word.Substring(0, lastUpperCaseIndex);
-
-                // Return the suffix word 
-                return word.Substring(lastUpperCaseIndex);
-            }
-            
-            // Return the word itself as the suffix word if a suffix cannot be extracted
-            return word;
+            return word.Substring(lastSpaceIndex + 1);
         }
 
+        static string ExtractSuffixByLastUpperCase(string word, out string prefixWord)
+        {
+            if (!word.Any(x => char.IsUpper(x)))
+            {
+                prefixWord = string.Empty;
+                return word;
+            }
+
+            var lastUpperCaseChar = word.Reverse().First(x => char.IsUpper(x));
+            var lastUpperCaseIndex = word.LastIndexOf(lastUpperCaseChar);
+
+            prefixWord = word.Substring(0, lastUpperCaseIndex);
+
+            return word.Substring(lastUpperCaseIndex);
+
+        }
         static bool IsCapitalized(string word)
             => !string.IsNullOrEmpty(word) && char.IsUpper(word, 0);
 

--- a/src/GUI/UnitTests/PluralizerTest.cs
+++ b/src/GUI/UnitTests/PluralizerTest.cs
@@ -26,5 +26,34 @@ namespace UnitTests
             // Assert
             Assert.AreEqual("CourseStatuses", result);
         }
+        [Test]
+        public void CanSingularizeCourseStatuses()
+        {
+            // Act
+            var result = new Pluralizer().Singularize("CourseStatuses");
+
+            // Assert
+            Assert.AreEqual("CourseStatus", result);
+        }
+
+        [Test]
+        public void CanSingularizeGames()
+        {
+            // Act
+            var result = new Pluralizer().Singularize("Games");
+
+            // Assert
+            Assert.AreEqual("Game", result);
+        }
+
+        [Test]
+        public void CanPluralizeGame()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("Game");
+
+            // Assert
+            Assert.AreEqual("Games", result);
+        }
     }
 }

--- a/src/GUI/UnitTests/PluralizerTest.cs
+++ b/src/GUI/UnitTests/PluralizerTest.cs
@@ -27,6 +27,15 @@ namespace UnitTests
             Assert.AreEqual("CourseStatuses", result);
         }
         [Test]
+        public void CanPluralizeCourseStatusWithSpace()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("Course Status");
+
+            // Assert
+            Assert.AreEqual("Course Statuses", result);
+        }
+        [Test]
         public void CanSingularizeCourseStatuses()
         {
             // Act
@@ -55,5 +64,16 @@ namespace UnitTests
             // Assert
             Assert.AreEqual("Games", result);
         }
+
+        [Test]
+        public void CanPluralizeWordWithSpaceAndUpperCase()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("Fun CourseStatus");
+
+            // Assert
+            Assert.AreEqual("Fun CourseStatuses", result);
+        }
+
     }
 }

--- a/src/GUI/UnitTests/PluralizerTest.cs
+++ b/src/GUI/UnitTests/PluralizerTest.cs
@@ -75,5 +75,24 @@ namespace UnitTests
             Assert.AreEqual("Fun CourseStatuses", result);
         }
 
+        [Test]
+        public void CanPluralizeStatus()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("Status");
+
+            // Assert
+            Assert.AreEqual("Statuses", result);
+        }
+
+        [Test]
+        public void CanPluralizeStatusLowerCase()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("status");
+
+            // Assert
+            Assert.AreEqual("statuses", result);
+        }
     }
 }

--- a/src/GUI/UnitTests/PluralizerTest.cs
+++ b/src/GUI/UnitTests/PluralizerTest.cs
@@ -16,5 +16,15 @@ namespace UnitTests
             // Assert
             Assert.AreEqual("People", result);
         }
+
+        [Test]
+        public void CanPluralizeCourseStatus()
+        {
+            // Act
+            var result = new Pluralizer().Pluralize("CourseStatus");
+
+            // Assert
+            Assert.AreEqual("CourseStatuses", result);
+        }
     }
 }


### PR DESCRIPTION
Fixes #60 
In the Pluralizer class, the suffix was being extracted using the last space in the string. I have included lines to extract suffix based on the last upper case letter in the string.
Also, I commented out  {"status", "status"} from _classicalInflectionList. Because of this, "status" suffix was considered as a plural word.