### PR TITLE
Refactored PickServerDatabase dialog

### DIFF
--- a/src/GUI/EFCorePowerTools.Shared/DAL/IVisualStudioAccess.cs
+++ b/src/GUI/EFCorePowerTools.Shared/DAL/IVisualStudioAccess.cs
@@ -1,10 +1,13 @@
 ﻿namespace EFCorePowerTools.Shared.DAL
 {
     using System;
+    using Models;
 
     public interface IVisualStudioAccess
     {
         void NavigateToUrl(string url);
+        DatabaseConnectionModel PromptForNewDatabaseConnection();
+        void ShowMessage(string message);
 
         bool IsDdexProviderInstalled(Guid id);
         bool IsSqLiteDbProviderInstalled();

--- a/src/GUI/EFCorePowerTools.Shared/Enums/DatabaseType.cs
+++ b/src/GUI/EFCorePowerTools.Shared/Enums/DatabaseType.cs
@@ -1,0 +1,14 @@
+﻿// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+namespace EFCorePowerTools.Shared.Enums
+{
+    public enum DatabaseType
+    {
+        Undefined = 0,
+        SQLCE35 = 1,
+        SQLCE40 = 2,
+        SQLServer = 3,
+        SQLite = 4,
+        Npgsql = 5
+    }
+}

--- a/src/GUI/EFCorePowerTools.Shared/Models/DatabaseConnectionModel.cs
+++ b/src/GUI/EFCorePowerTools.Shared/Models/DatabaseConnectionModel.cs
@@ -1,0 +1,58 @@
+﻿namespace EFCorePowerTools.Shared.Models
+{
+    using System.ComponentModel;
+    using System.Runtime.CompilerServices;
+    using Annotations;
+    using Enums;
+
+    /// <summary>
+    /// A model holding data about a database connection.
+    /// </summary>
+    public class DatabaseConnectionModel : INotifyPropertyChanged
+    {
+        private string _connectionName;
+        private string _connectionString;
+        private DatabaseType _databaseType;
+
+        public string ConnectionName
+        {
+            get => _connectionName;
+            set
+            {
+                if (value == _connectionName) return;
+                _connectionName = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string ConnectionString
+        {
+            get => _connectionString;
+            set
+            {
+                if (value == _connectionString) return;
+                _connectionString = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public DatabaseType DatabaseType
+        {
+            get => _databaseType;
+            set
+            {
+                if (value == _databaseType) return;
+                _databaseType = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/GUI/EFCorePowerTools.Shared/Models/DatabaseDefinitionModel.cs
+++ b/src/GUI/EFCorePowerTools.Shared/Models/DatabaseDefinitionModel.cs
@@ -1,0 +1,36 @@
+﻿namespace EFCorePowerTools.Shared.Models
+{
+    using System.ComponentModel;
+    using System.Runtime.CompilerServices;
+    using Annotations;
+
+    /// <summary>
+    /// A model holding data about a database definition, e.g. a DacPac file or database project.
+    /// </summary>
+    public class DatabaseDefinitionModel : INotifyPropertyChanged
+    {
+        private string _filePath;
+
+        /// <summary>
+        /// Gets or sets the file path to the database definition.
+        /// </summary>
+        public string FilePath
+        {
+            get => _filePath;
+            set
+            {
+                if (value == _filePath) return;
+                _filePath = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/GUI/EFCorePowerTools/Contracts/EventArgs/CloseRequestedEventArgs.cs
+++ b/src/GUI/EFCorePowerTools/Contracts/EventArgs/CloseRequestedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace EFCorePowerTools.Contracts.EventArgs
+{
+    using System;
+
+    public class CloseRequestedEventArgs : EventArgs
+    {
+        public bool? DialogResult { get; }
+
+        public CloseRequestedEventArgs(bool? dialogResult)
+        {
+            DialogResult = dialogResult;
+        }
+    }
+}

--- a/src/GUI/EFCorePowerTools/Contracts/ViewModels/IPickServerDatabaseViewModel.cs
+++ b/src/GUI/EFCorePowerTools/Contracts/ViewModels/IPickServerDatabaseViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace EFCorePowerTools.Contracts.ViewModels
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Windows.Input;
+    using Shared.Models;
+
+    public interface IPickServerDatabaseViewModel : IViewModel
+    {
+        event EventHandler CloseRequested;
+
+        ICommand LoadedCommand { get; }
+        ICommand AddDatabaseConnectionCommand { get; }
+        ICommand OkCommand { get; }
+        ICommand CancelCommand { get; }
+
+        ObservableCollection<DatabaseConnectionModel> DatabaseConnections { get; }
+        ObservableCollection<DatabaseDefinitionModel> DatabaseDefinitions { get; }
+
+        DatabaseConnectionModel SelectedDatabaseConnection { get; set; }
+        DatabaseDefinitionModel SelectedDatabaseDefinition { get; set; }
+    }
+}

--- a/src/GUI/EFCorePowerTools/Contracts/ViewModels/IPickServerDatabaseViewModel.cs
+++ b/src/GUI/EFCorePowerTools/Contracts/ViewModels/IPickServerDatabaseViewModel.cs
@@ -3,11 +3,12 @@
     using System;
     using System.Collections.ObjectModel;
     using System.Windows.Input;
+    using EventArgs;
     using Shared.Models;
 
     public interface IPickServerDatabaseViewModel : IViewModel
     {
-        event EventHandler CloseRequested;
+        event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
         ICommand LoadedCommand { get; }
         ICommand AddDatabaseConnectionCommand { get; }

--- a/src/GUI/EFCorePowerTools/Contracts/Views/IPickServerDatabaseDialog.cs
+++ b/src/GUI/EFCorePowerTools/Contracts/Views/IPickServerDatabaseDialog.cs
@@ -1,7 +1,11 @@
 ﻿namespace EFCorePowerTools.Contracts.Views
 {
-    public interface IPickServerDatabaseDialog : IDialog<object>
+    using System.Collections.Generic;
+    using Shared.Models;
+
+    public interface IPickServerDatabaseDialog : IDialog<(DatabaseConnectionModel Connection, DatabaseDefinitionModel Definition)>
     {
-        
+        void PublishConnections(IEnumerable<DatabaseConnectionModel> connections);
+        void PublishDefinitions(IEnumerable<DatabaseDefinitionModel> definitions);
     }
 }

--- a/src/GUI/EFCorePowerTools/Converter/CollectionCountToVisibilityConverter.cs
+++ b/src/GUI/EFCorePowerTools/Converter/CollectionCountToVisibilityConverter.cs
@@ -1,0 +1,29 @@
+﻿namespace EFCorePowerTools.Converter
+{
+    using System;
+    using System.Collections;
+    using System.Globalization;
+    using System.Windows;
+    using System.Windows.Data;
+
+    public class CollectionCountToVisibilityConverter : IValueConverter
+    {
+        object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (targetType != typeof(Visibility))
+                throw new ArgumentException(@"Value must be of type System.Windows.Visibility.", nameof(targetType));
+
+            if (!(value is ICollection c))
+                throw new ArgumentException(@"Value must implement type System.Collections.ICollection.", nameof(value));
+
+            return c.Count > 0
+                       ? Visibility.Visible
+                       : Visibility.Collapsed;
+        }
+
+        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/GUI/EFCorePowerTools/Converter/FilePathToDisplayNameConverter.cs
+++ b/src/GUI/EFCorePowerTools/Converter/FilePathToDisplayNameConverter.cs
@@ -1,0 +1,39 @@
+﻿namespace EFCorePowerTools.Converter
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Windows.Data;
+
+    public class FilePathToDisplayNameConverter : IValueConverter
+    {
+        object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (targetType != typeof(string))
+                throw new ArgumentException(@"Value must be of type System.String.", nameof(targetType));
+
+            if (!(value is string s))
+                throw new ArgumentException(@"Value must be of type System.String.", nameof(value));
+
+            if (string.IsNullOrWhiteSpace(s))
+                return "<null>";
+
+            if (s.EndsWith(".sqlproj"))
+                return Path.GetFileNameWithoutExtension(s);
+
+            if (s.EndsWith(".dacpac"))
+            {
+                return s.Length > 55
+                           ? "..." + s.Substring(s.Length - 55)
+                           : s;
+            }
+
+            return s;
+        }
+
+        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/GUI/EFCorePowerTools/DAL/VisualStudioAccess.cs
+++ b/src/GUI/EFCorePowerTools/DAL/VisualStudioAccess.cs
@@ -4,19 +4,43 @@
     using EnvDTE80;
     using ErikEJ.SqlCeToolbox.Helpers;
     using Shared.DAL;
+    using Shared.Enums;
+    using Shared.Models;
 
     public class VisualStudioAccess : IVisualStudioAccess
     {
+        private readonly EFCorePowerToolsPackage _package;
         private readonly DTE2 _dte2;
 
-        public VisualStudioAccess(DTE2 dte2)
+        public VisualStudioAccess(EFCorePowerToolsPackage package,
+                                  DTE2 dte2)
         {
+            _package = package;
             _dte2 = dte2;
         }
 
         void IVisualStudioAccess.NavigateToUrl(string url)
         {
             _dte2.ItemOperations.Navigate(url);
+        }
+
+        DatabaseConnectionModel IVisualStudioAccess.PromptForNewDatabaseConnection()
+        {
+            var info = EnvDteHelper.PromptForInfo(_package);
+            if (info.DatabaseType == DatabaseType.SQLCE35)
+                return null;
+
+            return new DatabaseConnectionModel
+            {
+                ConnectionName = info.Caption,
+                ConnectionString = info.ConnectionString,
+                DatabaseType = info.DatabaseType
+            };
+        }
+
+        void IVisualStudioAccess.ShowMessage(string message)
+        {
+            EnvDteHelper.ShowMessage(message);
         }
 
         bool IVisualStudioAccess.IsDdexProviderInstalled(Guid id)

--- a/src/GUI/EFCorePowerTools/DAL/VisualStudioAccess.cs
+++ b/src/GUI/EFCorePowerTools/DAL/VisualStudioAccess.cs
@@ -27,7 +27,7 @@
         DatabaseConnectionModel IVisualStudioAccess.PromptForNewDatabaseConnection()
         {
             var info = EnvDteHelper.PromptForInfo(_package);
-            if (info.DatabaseType == DatabaseType.SQLCE35)
+            if (info.DatabaseType == DatabaseType.Undefined)
                 return null;
 
             return new DatabaseConnectionModel

--- a/src/GUI/EFCorePowerTools/Dialogs/Converter.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/Converter.xaml
@@ -4,5 +4,7 @@
     xmlns:converter="clr-namespace:EFCorePowerTools.Converter">
 
     <converter:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    <converter:FilePathToDisplayNameConverter x:Key="FilePathToDisplayNameConverter"/>
+    <converter:CollectionCountToVisibilityConverter x:Key="CollectionCountToVisibilityConverter"/>
 
 </ResourceDictionary>

--- a/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml
@@ -1,39 +1,109 @@
-﻿<dw:DialogWindow x:Class="ErikEJ.SqlCeToolbox.Dialogs.PickServerDatabaseDialog"
-        xmlns:dw="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Choose Database Connection" 
-        WindowStyle="SingleBorderWindow"
-        WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize" 
-        ShowInTaskbar="False"
-        mc:Ignorable="d" 
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-        SizeToContent="WidthAndHeight" Loaded="Window_Loaded" Width="418.653" Height="250.581">
+﻿<dw:DialogWindow x:Class="EFCorePowerTools.Dialogs.PickServerDatabaseDialog"
+                 xmlns:dw="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+                 Title="Choose Database Connection" 
+                 WindowStyle="SingleBorderWindow"
+                 WindowStartupLocation="CenterOwner"
+                 ResizeMode="NoResize" 
+                 ShowInTaskbar="False"
+                 mc:Ignorable="d" 
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:viewModels="clr-namespace:EFCorePowerTools.ViewModels"
+                 Loaded="Window_Loaded"
+                 Width="420"
+                 Height="190"
+                 d:DataContext="{d:DesignInstance Type=viewModels:PickServerDatabaseViewModel, IsDesignTimeCreatable=False}">
+
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="Loaded">
+            <i:InvokeCommandAction Command="{Binding LoadedCommand}" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <dw:DialogWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../Dialogs/Style.xaml"/>
+                <ResourceDictionary Source="Style.xaml"/>
+                <ResourceDictionary Source="Converter.xaml"/>
+                <ResourceDictionary>
+                    <Style x:Key="SourceSelectionComboBoxStyle" TargetType="ComboBox">
+                        <Setter Property="Margin" Value="0, 12, 0, 12"/>
+                    </Style>
+                    <Style x:Key="SourceSelectionButtonStyle" TargetType="Button">
+                        <Setter Property="Margin" Value="10, 0, 0, 0"/>
+                        <Setter Property="VerticalAlignment" Value="Center"/>
+                        <Setter Property="Padding" Value="10, 2"/>
+                    </Style>
+                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </dw:DialogWindow.Resources>
-    <Grid Margin="12,24,12,12">
-        <Grid.RowDefinitions>
 
-            <RowDefinition Height="2" />
-            <RowDefinition Height="38" />
-            <RowDefinition Height="38" />
-            <RowDefinition Height="38" />
-            <RowDefinition Height="100*" />
+    <dw:DialogWindow.Background>
+        <StaticResource ResourceKey="DialogWindowBackgroundColor"/>
+    </dw:DialogWindow.Background>
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <StackPanel Margin="0,0, 0,0" Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Width="385">
-            <ComboBox Height="23" HorizontalAlignment="Left" x:Name="comboBox1" VerticalAlignment="Top" Width="293" IsEditable="False" SelectionChanged="comboBox1_SelectionChanged" TabIndex="0" Margin="0,12,6,0" />
-            <dw:DialogButton  Click="AddButton_OnClick" HorizontalAlignment="Right" TabIndex="1" SnapsToDevicePixels="False" Width="74" Margin="0,12,0,0" Height="23" VerticalAlignment="Top" Content="Add..."/>
+
+        <Grid Grid.Row="0"
+                   HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <ComboBox Grid.Column="0"
+                      x:Name="DatabaseConnectionCombobox"
+                      TabIndex="1"
+                      Style="{StaticResource SourceSelectionComboBoxStyle}"
+                      ItemsSource="{Binding DatabaseConnections, Mode=OneWay}"
+                      SelectedItem="{Binding SelectedDatabaseConnection, Mode=TwoWay}"
+                      DisplayMemberPath="ConnectionName"/>
+            <Button Grid.Column="1"
+                    TabIndex="2"
+                    Style="{StaticResource SourceSelectionButtonStyle}"
+                    Content="Add..."
+                    Command="{Binding AddDatabaseConnectionCommand}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="1"
+                   Visibility="{Binding DatabaseDefinitions, Converter={StaticResource CollectionCountToVisibilityConverter}, Mode=OneWay}"
+                   Text="or SQL Server Database project (.dacpac)"/>
+        <ComboBox Grid.Row="2"
+                  Visibility="{Binding DatabaseDefinitions, Converter={StaticResource CollectionCountToVisibilityConverter}, Mode=OneWay}"
+                  TabIndex="3"
+                  Style="{StaticResource SourceSelectionComboBoxStyle}"
+                  ItemsSource="{Binding DatabaseDefinitions, Mode=OneWay}"
+                  SelectedItem="{Binding SelectedDatabaseDefinition, Mode=TwoWay}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding FilePath, Converter={StaticResource FilePathToDisplayNameConverter}}"/>
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center">
+            <Button TabIndex="4"
+                    Style="{StaticResource SourceSelectionButtonStyle}"
+                    Content="OK"
+                    IsDefault="True"
+                    Command="{Binding OkCommand}"/>
+            <Button TabIndex="5" 
+                    Style="{StaticResource SourceSelectionButtonStyle}"
+                    Content="Cancel"
+                    Command="{Binding CancelCommand}"/>
         </StackPanel>
-        <Label Grid.Row="2" HorizontalAlignment="Left" Margin="0,12,0,0" Width="362">or SQL Server Database project (.dacpac)</Label>
-        <ComboBox Height="23" HorizontalAlignment="Left" Grid.Row="3" Name="comboBox2" VerticalAlignment="Top" Width="373" SelectionChanged="comboBox2_SelectionChanged" IsEditable="False" TabIndex="0" Margin="2,10,0,0" />
-        <dw:DialogButton IsDefault="True"   Click="SaveButton_Click" Grid.Row="4" HorizontalAlignment="Right" TabIndex="2" Margin="0,28,98.5,0" Width="74" Height="25" VerticalAlignment="Top">OK</dw:DialogButton>
-        <dw:DialogButton IsCancel="True" Click="CancelButton_Click" Grid.Row="4" HorizontalAlignment="Right" TabIndex="3" SnapsToDevicePixels="False" Width="74" Margin="0,28,13.5,0" Height="25" VerticalAlignment="Top">Cancel</dw:DialogButton>
     </Grid>
 </dw:DialogWindow>

--- a/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml
@@ -14,7 +14,7 @@
                  xmlns:viewModels="clr-namespace:EFCorePowerTools.ViewModels"
                  Loaded="Window_Loaded"
                  Width="420"
-                 Height="190"
+                 Height="200"
                  d:DataContext="{d:DesignInstance Type=viewModels:PickServerDatabaseViewModel, IsDesignTimeCreatable=False}">
 
     <i:Interaction.Triggers>
@@ -32,10 +32,9 @@
                     <Style x:Key="SourceSelectionComboBoxStyle" TargetType="ComboBox">
                         <Setter Property="Margin" Value="0, 12, 0, 12"/>
                     </Style>
-                    <Style x:Key="SourceSelectionButtonStyle" TargetType="Button">
+                    <Style x:Key="SourceSelectionButtonStyle" TargetType="dw:DialogButton">
                         <Setter Property="Margin" Value="10, 0, 0, 0"/>
                         <Setter Property="VerticalAlignment" Value="Center"/>
-                        <Setter Property="Padding" Value="10, 2"/>
                     </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -68,11 +67,11 @@
                       ItemsSource="{Binding DatabaseConnections, Mode=OneWay}"
                       SelectedItem="{Binding SelectedDatabaseConnection, Mode=TwoWay}"
                       DisplayMemberPath="ConnectionName"/>
-            <Button Grid.Column="1"
-                    TabIndex="2"
-                    Style="{StaticResource SourceSelectionButtonStyle}"
-                    Content="Add..."
-                    Command="{Binding AddDatabaseConnectionCommand}"/>
+            <dw:DialogButton Grid.Column="1"
+                             TabIndex="2"
+                             Style="{StaticResource SourceSelectionButtonStyle}"
+                             Content="Add..."
+                             Command="{Binding AddDatabaseConnectionCommand}"/>
         </Grid>
 
         <TextBlock Grid.Row="1"
@@ -95,15 +94,15 @@
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center">
-            <Button TabIndex="4"
-                    Style="{StaticResource SourceSelectionButtonStyle}"
-                    Content="OK"
-                    IsDefault="True"
-                    Command="{Binding OkCommand}"/>
-            <Button TabIndex="5" 
-                    Style="{StaticResource SourceSelectionButtonStyle}"
-                    Content="Cancel"
-                    Command="{Binding CancelCommand}"/>
+            <dw:DialogButton TabIndex="4"
+                             Style="{StaticResource SourceSelectionButtonStyle}"
+                             Content="OK"
+                             IsDefault="True"
+                             Command="{Binding OkCommand}"/>
+            <dw:DialogButton TabIndex="5"
+                             Style="{StaticResource SourceSelectionButtonStyle}"
+                             Content="Cancel"
+                             Command="{Binding CancelCommand}"/>
         </StackPanel>
     </Grid>
 </dw:DialogWindow>

--- a/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml.cs
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml.cs
@@ -1,99 +1,74 @@
-﻿using System;
-using System.Windows;
-using System.Collections.Generic;
-using ErikEJ.SqlCeToolbox.Helpers;
-
-namespace ErikEJ.SqlCeToolbox.Dialogs
+﻿namespace EFCorePowerTools.Dialogs
 {
-    using EFCorePowerTools.Shared.Enums;
+    using System;
+    using System.Collections.Generic;
+    using System.Windows;
+    using Contracts.ViewModels;
+    using Contracts.Views;
+    using Shared.DAL;
+    using Shared.Models;
 
-    public partial class PickServerDatabaseDialog
+    public partial class PickServerDatabaseDialog : IPickServerDatabaseDialog
     {
-        public KeyValuePair<string, DatabaseInfo> SelectedDatabase { get; private set; }
+        private readonly Func<(DatabaseConnectionModel Connection, DatabaseDefinitionModel Definition)> _getDialogResult;
+        private readonly Action<IEnumerable<DatabaseConnectionModel>> _addConnections;
+        private readonly Action<IEnumerable<DatabaseDefinitionModel>> _addDefinitions;
 
-        public string DacpacPath { get; private set; }
-
-        private readonly EFCorePowerTools.EFCorePowerToolsPackage _package;
-
-        public PickServerDatabaseDialog(Dictionary<string, DatabaseInfo> serverConnections, EFCorePowerTools.EFCorePowerToolsPackage package, Dictionary<string, string> dacpacList)
+        public PickServerDatabaseDialog(ITelemetryAccess telemetryAccess,
+                                        IPickServerDatabaseViewModel viewModel)
         {
-            _package = package;
-            Telemetry.TrackPageView(nameof(PickServerDatabaseDialog));
+            telemetryAccess.TrackPageView(nameof(PickServerDatabaseDialog));
+
+            DataContext = viewModel;
+            viewModel.CloseRequested += (sender, args) =>
+            {
+                DialogResult = args.DialogResult;
+                Close();
+            };
+            _getDialogResult = () => (viewModel.SelectedDatabaseConnection, viewModel.SelectedDatabaseDefinition);
+            _addConnections = models =>
+            {
+                foreach (var model in models)
+                    viewModel.DatabaseConnections.Add(model);
+            };
+            _addDefinitions = models =>
+            {
+                foreach (var model in models)
+                    viewModel.DatabaseDefinitions.Add(model);
+            };
+
             InitializeComponent();
-            Background = VsThemes.GetWindowBackground();
-            comboBox1.DisplayMemberPath = "Value.Caption";
-            comboBox1.ItemsSource = serverConnections;
-            comboBox2.DisplayMemberPath = "Key";
-            comboBox2.ItemsSource = dacpacList;
-            if (serverConnections.Count > 0)
-            {
-                comboBox1.SelectedIndex = 0;
-            }
-        }
-
-        private void SaveButton_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = true;
-            Close();
-        }
-
-        private void CancelButton_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
-        }
-
-        private void comboBox1_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            if (comboBox1.SelectedItem != null)
-            {
-                SelectedDatabase = (KeyValuePair<string, DatabaseInfo>)comboBox1.SelectedItem;
-                DacpacPath = null;
-                comboBox2.SelectedIndex = -1;
-            };
-        }
-
-        private void comboBox2_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            if (comboBox2.SelectedItem != null)
-            {
-                var result = (KeyValuePair<string, string>)comboBox2.SelectedItem;
-                DacpacPath = result.Value;
-                comboBox1.SelectedIndex = -1;
-            };
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            comboBox1.Focus();
+            DatabaseConnectionCombobox.Focus();
         }
 
-        private void AddButton_OnClick(object sender, RoutedEventArgs e)
+        public (bool ClosedByOK, (DatabaseConnectionModel Connection, DatabaseDefinitionModel Definition) Payload) ShowAndAwaitUserResponse(bool modal)
         {
-            try
-            {
-                var info = EnvDteHelper.PromptForInfo(_package);
-                if (info.DatabaseType == DatabaseType.SQLCE35) return;
+            bool closedByOkay;
 
-                var databaseList = EnvDteHelper.GetDataConnections(_package);
-                comboBox1.DisplayMemberPath = "Value.Caption";
-                comboBox1.ItemsSource = databaseList;
-
-                int i = 0;
-                foreach (var item in databaseList)
-                {
-                    if (item.Key == info.ConnectionString)
-                    {
-                        comboBox1.SelectedIndex = i;
-                    }
-                    i++;
-                }
-            }
-            catch (Exception exception)
+            if (modal)
             {
-                EnvDteHelper.ShowMessage("Unable to add connection, maybe the provider is not supported: "  + exception.Message);
+                closedByOkay = ShowModal() == true;
             }
+            else
+            {
+                closedByOkay = ShowDialog() == true;
+            }
+
+            return (closedByOkay, _getDialogResult());
         }
 
+        void IPickServerDatabaseDialog.PublishConnections(IEnumerable<DatabaseConnectionModel> connections)
+        {
+            _addConnections(connections);
+        }
+
+        void IPickServerDatabaseDialog.PublishDefinitions(IEnumerable<DatabaseDefinitionModel> definitions)
+        {
+            _addDefinitions(definitions);
+        }
     }
 }

--- a/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml.cs
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickServerDatabaseDialog.xaml.cs
@@ -5,6 +5,8 @@ using ErikEJ.SqlCeToolbox.Helpers;
 
 namespace ErikEJ.SqlCeToolbox.Dialogs
 {
+    using EFCorePowerTools.Shared.Enums;
+
     public partial class PickServerDatabaseDialog
     {
         public KeyValuePair<string, DatabaseInfo> SelectedDatabase { get; private set; }

--- a/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
+++ b/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
@@ -55,6 +55,7 @@
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Contracts\EventArgs\CloseRequestedEventArgs.cs" />
     <Compile Include="Contracts\ViewModels\IAboutViewModel.cs" />
     <Compile Include="Contracts\ViewModels\IPickServerDatabaseViewModel.cs" />
     <Compile Include="Contracts\ViewModels\IViewModel.cs" />
@@ -66,6 +67,8 @@
     <Compile Include="Contracts\Views\IPickTablesDialog.cs" />
     <Compile Include="Contracts\Views\IView.cs" />
     <Compile Include="Converter\BoolToVisibilityConverter.cs" />
+    <Compile Include="Converter\FilePathToDisplayNameConverter.cs" />
+    <Compile Include="Converter\CollectionCountToVisibilityConverter.cs" />
     <Compile Include="DAL\DotNetAccess.cs" />
     <Compile Include="DAL\FileSystemAccess.cs" />
     <Compile Include="DAL\OperatingSystemAccess.cs" />

--- a/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
+++ b/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
@@ -56,6 +56,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Contracts\ViewModels\IAboutViewModel.cs" />
+    <Compile Include="Contracts\ViewModels\IPickServerDatabaseViewModel.cs" />
     <Compile Include="Contracts\ViewModels\IViewModel.cs" />
     <Compile Include="Contracts\Views\IAboutDialog.cs" />
     <Compile Include="Contracts\Views\IDialog.cs" />
@@ -124,6 +125,7 @@
     </Compile>
     <Compile Include="ViewModels\AboutViewModel.cs" />
     <Compile Include="DAL\VisualStudioAccess.cs" />
+    <Compile Include="ViewModels\PickServerDatabaseViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\lib\efpt.exe.zip">

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
@@ -247,7 +247,8 @@ namespace EFCorePowerTools
             services.AddSingleton<AboutExtensionModel>();
 
             // Register views
-            services.AddTransient<IAboutDialog, AboutDialog>();
+            services.AddTransient<IAboutDialog, AboutDialog>()
+                    .AddTransient<IPickServerDatabaseDialog, PickServerDatabaseDialog>();
 
             // Register view models
             services.AddTransient<IAboutViewModel, AboutViewModel>()

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
@@ -250,7 +250,8 @@ namespace EFCorePowerTools
             services.AddTransient<IAboutDialog, AboutDialog>();
 
             // Register view models
-            services.AddTransient<IAboutViewModel, AboutViewModel>();
+            services.AddTransient<IAboutViewModel, AboutViewModel>()
+                    .AddTransient<IPickServerDatabaseViewModel, PickServerDatabaseViewModel>();
 
             // Register BLL
             var messenger = new Messenger();
@@ -261,7 +262,7 @@ namespace EFCorePowerTools
                     .AddSingleton<IMessenger>(messenger);
 
             // Register DAL
-            services.AddTransient<IVisualStudioAccess, VisualStudioAccess>(provider => new VisualStudioAccess(_dte2))
+            services.AddTransient<IVisualStudioAccess, VisualStudioAccess>(provider => new VisualStudioAccess(this, _dte2))
                     .AddSingleton<ITelemetryAccess, TelemetryAccess>()
                     .AddSingleton<IOperatingSystemAccess, OperatingSystemAccess>()
                     .AddSingleton<IFileSystemAccess, FileSystemAccess>()

--- a/src/GUI/EFCorePowerTools/Extensions/EvnDTEExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/EvnDTEExtensions.cs
@@ -7,46 +7,36 @@ namespace EFCorePowerTools.Extensions
 {
     internal static class EvnDTEExtensions
     {
-        public static Dictionary<string, string> GetDacpacFilesInActiveSolution(this DTE dte)
+        public static string[] GetDacpacFilesInActiveSolution(this DTE dte)
         {
-            var result = new Dictionary<string, string>();
+            var result = new List<string>();
 
             if (!dte.Solution.IsOpen)
-            {
-                result.Add("No open Solution", null);
-                return result;
-            }
+                return null;
 
-            string path = null;
-            TryGetInitialPath(dte, out path);
+            TryGetInitialPath(dte, out var path);
 
             if (path != null)
             {
                 var files = DirSearch(path, "*.sqlproj");
-                foreach (string file in files)
+                foreach (var file in files)
                 {
-                    var key = Path.GetFileNameWithoutExtension(file);
-                    if (!result.ContainsKey(key))
-                        result.Add(key, file);
+                    if (!result.Contains(file))
+                        result.Add(file);
                 }
 
                 files = DirSearch(path, "*.dacpac");
-                foreach (string file in files)
+                foreach (var file in files)
                 {
-                    var key = file;
-                    if (key.Length > 55)
-                    {
-                        key = "..." + key.Substring(key.Length - 55);
-                    }
-                    if (!result.ContainsKey(key))
-                        result.Add(key, file);
+                    if (!result.Contains(file))
+                        result.Add(file);
                 }
             }
 
             if (result.Count == 0)
-                result.Add("No .dacpac files found in Solution folders", null);
+                return null;
 
-            return result;
+            return result.ToArray();
         }
 
         public static string BuildSqlProj(this DTE dte, string sqlprojPath)

--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -6,6 +6,8 @@ using VSLangProj;
 
 namespace EFCorePowerTools.Extensions
 {
+    using Shared.Enums;
+
     internal static class ProjectExtensions
     {
         public const int SOk = 0;

--- a/src/GUI/EFCorePowerTools/Extensions/ReverseEngineerOptionsExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ReverseEngineerOptionsExtensions.cs
@@ -7,6 +7,8 @@ using System.Text;
 
 namespace EFCorePowerTools.Extensions
 {
+    using System.Runtime.Serialization;
+
     internal static class ReverseEngineerOptionsExtensions
     {
         public static ReverseEngineerOptions TryRead(string optionsPath)
@@ -14,16 +16,20 @@ namespace EFCorePowerTools.Extensions
             if (!File.Exists(optionsPath)) return null;
             if (File.Exists(optionsPath + ".ignore")) return null;
 
-            ReverseEngineerOptions deserializedOptions = null;
-            try
-            {
-                var ms = new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(optionsPath, Encoding.UTF8)));
-                var ser = new DataContractJsonSerializer(typeof(ReverseEngineerOptions));
-                deserializedOptions = ser.ReadObject(ms) as ReverseEngineerOptions;
-                ms.Close();
-            }
-            catch { }
-            return deserializedOptions;
+            // Top-down deserialization:
+            // Try to deserialize the current head version of the class.
+            // If this fails, go top down with older versions and migrate them to the head version.
+
+            var couldRead = TryRead(optionsPath, out ReverseEngineerOptions deserialized);
+            if (couldRead)
+                return deserialized;
+
+            couldRead = TryRead(optionsPath, out ReverseEngineerOptionsV1 deserializedV1);
+            if (couldRead)
+                return ReverseEngineerOptions.FromV1(deserializedV1);
+
+            // Fallback
+            return null;
         }
 
         public static string Write(this ReverseEngineerOptions options)
@@ -34,6 +40,23 @@ namespace EFCorePowerTools.Extensions
             byte[] json = ms.ToArray();
             ms.Close();
             return Encoding.UTF8.GetString(json, 0, json.Length);
+        }
+
+        private static bool TryRead<T>(string optionsPath, out T deserialized) where T : class, new()
+        {
+            try
+            {
+                var ms = new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(optionsPath, Encoding.UTF8)));
+                var ser = new DataContractJsonSerializer(typeof(T));
+                deserialized = ser.ReadObject(ms) as T;
+                ms.Close();
+                return true;
+            }
+            catch
+            {
+                deserialized = null;
+                return false;
+            }
         }
     }
 }

--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
@@ -14,6 +14,7 @@ using System.Text;
 namespace EFCorePowerTools.Handlers
 {
     using ReverseEngineer20.ReverseEngineer;
+    using Shared.Enums;
 
     internal class ReverseEngineerHandler
     {

--- a/src/GUI/EFCorePowerTools/Handlers/ServerDgmlHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ServerDgmlHandler.cs
@@ -9,6 +9,7 @@ namespace EFCorePowerTools.Handlers
 {
     using System.Linq;
     using ReverseEngineer20.ReverseEngineer;
+    using Shared.Enums;
 
     internal class ServerDgmlHandler
     {

--- a/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
+++ b/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
@@ -15,6 +15,7 @@ using System.Windows.Forms;
 // ReSharper disable once CheckNamespace
 namespace ErikEJ.SqlCeToolbox.Helpers
 {
+    using EFCorePowerTools.Shared.Enums;
     using ReverseEngineer20.ReverseEngineer;
 
     internal class EnvDteHelper

--- a/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
+++ b/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
@@ -108,10 +108,10 @@ namespace ErikEJ.SqlCeToolbox.Helpers
             dialog.SelectedSource = new Guid("067ea0d9-ba62-43f7-9106-34930c60c528");
             var dialogResult = dialog.ShowDialog(connect: true);
 
-            if (dialogResult == null) return new DatabaseInfo {DatabaseType = DatabaseType.SQLCE35};
+            if (dialogResult == null) return new DatabaseInfo {DatabaseType = DatabaseType.Undefined};
 
             var info = GetDatabaseInfo(package, dialogResult.Provider, DataProtection.DecryptString(dialog.EncryptedConnectionString));
-            if (info.Size == Guid.Empty.ToString()) return new DatabaseInfo { DatabaseType = DatabaseType.SQLCE35 };
+            if (info.Size == Guid.Empty.ToString()) return new DatabaseInfo { DatabaseType = DatabaseType.Undefined };
 
             SaveDataConnection(package, dialog.EncryptedConnectionString, info.DatabaseType, new Guid(info.Size));
             return info;

--- a/src/GUI/EFCorePowerTools/Helpers/Model.cs
+++ b/src/GUI/EFCorePowerTools/Helpers/Model.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using EFCorePowerTools.Shared.Enums;
 
 [DefaultProperty("Caption")]
 // ReSharper disable once CheckNamespace
@@ -67,16 +68,6 @@ public class TableInfo
     public Int64 RowCount { get; set; }
 }
 
-
-[SuppressMessage("ReSharper", "InconsistentNaming")]
-public enum DatabaseType
-{
-    SQLCE35,
-    SQLCE40,
-    SQLServer,
-    SQLite,
-    Npgsql
-}
 /// <summary>
 /// A model used to communicate with DescriptionDialog for table+column descriptions
 /// </summary>

--- a/src/GUI/EFCorePowerTools/Helpers/RepositoryHelper.cs
+++ b/src/GUI/EFCorePowerTools/Helpers/RepositoryHelper.cs
@@ -5,6 +5,8 @@ using System.IO;
 
 namespace ErikEJ.SqlCeToolbox.Helpers
 {
+    using EFCorePowerTools.Shared.Enums;
+
     internal static class RepositoryHelper
     {
         //TODO Update this when SQLite provider is updated!

--- a/src/GUI/EFCorePowerTools/ViewModels/PickServerDatabaseViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/PickServerDatabaseViewModel.cs
@@ -4,6 +4,7 @@
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Windows.Input;
+    using Contracts.EventArgs;
     using Contracts.ViewModels;
     using GalaSoft.MvvmLight;
     using GalaSoft.MvvmLight.CommandWpf;
@@ -17,7 +18,7 @@
         private DatabaseConnectionModel _selectedDatabaseConnection;
         private DatabaseDefinitionModel _selectedDatabaseDefinition;
 
-        public event EventHandler CloseRequested;
+        public event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
         public ICommand LoadedCommand { get; }
         public ICommand AddDatabaseConnectionCommand { get; }
@@ -66,6 +67,7 @@
 
             DatabaseConnections = new ObservableCollection<DatabaseConnectionModel>();
             DatabaseDefinitions = new ObservableCollection<DatabaseDefinitionModel>();
+            DatabaseDefinitions.CollectionChanged += (sender, args) => RaisePropertyChanged(nameof(DatabaseDefinitions));
         }
 
         private void Loaded_Executed()
@@ -96,7 +98,7 @@
 
         private void Ok_Executed()
         {
-            CloseRequested?.Invoke(this, EventArgs.Empty);
+            CloseRequested?.Invoke(this, new CloseRequestedEventArgs(true));
         }
 
         private bool Ok_CanExecute() => SelectedDatabaseConnection != null || SelectedDatabaseDefinition != null;
@@ -105,7 +107,7 @@
         {
             SelectedDatabaseConnection = null;
             SelectedDatabaseDefinition = null;
-            CloseRequested?.Invoke(this, EventArgs.Empty);
+            CloseRequested?.Invoke(this, new CloseRequestedEventArgs(false));
         }
     }
 }

--- a/src/GUI/EFCorePowerTools/ViewModels/PickServerDatabaseViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/PickServerDatabaseViewModel.cs
@@ -1,0 +1,111 @@
+﻿namespace EFCorePowerTools.ViewModels
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Windows.Input;
+    using Contracts.ViewModels;
+    using GalaSoft.MvvmLight;
+    using GalaSoft.MvvmLight.CommandWpf;
+    using Shared.DAL;
+    using Shared.Models;
+
+    public class PickServerDatabaseViewModel : ViewModelBase, IPickServerDatabaseViewModel
+    {
+        private readonly IVisualStudioAccess _visualStudioAccess;
+
+        private DatabaseConnectionModel _selectedDatabaseConnection;
+        private DatabaseDefinitionModel _selectedDatabaseDefinition;
+
+        public event EventHandler CloseRequested;
+
+        public ICommand LoadedCommand { get; }
+        public ICommand AddDatabaseConnectionCommand { get; }
+        public ICommand OkCommand { get; }
+        public ICommand CancelCommand { get; }
+
+        public ObservableCollection<DatabaseConnectionModel> DatabaseConnections { get; }
+        public ObservableCollection<DatabaseDefinitionModel> DatabaseDefinitions { get; }
+
+        public DatabaseConnectionModel SelectedDatabaseConnection
+        {
+            get => _selectedDatabaseConnection;
+            set
+            {
+                if (Equals(value, _selectedDatabaseConnection)) return;
+                _selectedDatabaseConnection = value;
+                RaisePropertyChanged();
+
+                if (_selectedDatabaseConnection != null)
+                    SelectedDatabaseDefinition = null;
+            }
+        }
+
+        public DatabaseDefinitionModel SelectedDatabaseDefinition
+        {
+            get => _selectedDatabaseDefinition;
+            set
+            {
+                if (Equals(value, _selectedDatabaseDefinition)) return;
+                _selectedDatabaseDefinition = value;
+                RaisePropertyChanged();
+
+                if (_selectedDatabaseDefinition != null)
+                    SelectedDatabaseConnection = null;
+            }
+        }
+
+        public PickServerDatabaseViewModel(IVisualStudioAccess visualStudioAccess)
+        {
+            _visualStudioAccess = visualStudioAccess ?? throw new ArgumentNullException(nameof(visualStudioAccess));
+
+            LoadedCommand = new RelayCommand(Loaded_Executed);
+            AddDatabaseConnectionCommand = new RelayCommand(AddDatabaseConnection_Executed);
+            OkCommand = new RelayCommand(Ok_Executed, Ok_CanExecute);
+            CancelCommand = new RelayCommand(Cancel_Executed);
+
+            DatabaseConnections = new ObservableCollection<DatabaseConnectionModel>();
+            DatabaseDefinitions = new ObservableCollection<DatabaseDefinitionModel>();
+        }
+
+        private void Loaded_Executed()
+        {
+            if (DatabaseConnections.Any())
+                SelectedDatabaseConnection = DatabaseConnections.First();
+        }
+
+        private void AddDatabaseConnection_Executed()
+        {
+            DatabaseConnectionModel newDatabaseConnection;
+            try
+            {
+                newDatabaseConnection = _visualStudioAccess.PromptForNewDatabaseConnection();
+            }
+            catch (Exception e)
+            {
+                _visualStudioAccess.ShowMessage("Unable to add connection, maybe the provider is not supported: " + e.Message);
+                return;
+            }
+
+            if (newDatabaseConnection == null)
+                return;
+
+            DatabaseConnections.Add(newDatabaseConnection);
+            SelectedDatabaseConnection = newDatabaseConnection;
+        }
+
+        private void Ok_Executed()
+        {
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+        }
+
+        private bool Ok_CanExecute() => SelectedDatabaseConnection != null || SelectedDatabaseDefinition != null;
+
+        private void Cancel_Executed()
+        {
+            SelectedDatabaseConnection = null;
+            SelectedDatabaseDefinition = null;
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/DatabaseType.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/DatabaseType.cs
@@ -3,10 +3,11 @@ namespace ReverseEngineer20
 {
     public enum DatabaseType
     {
-        SQLCE35,
-        SQLCE40,
-        SQLServer,
-        SQLite,
-        Npgsql
+        Undefined = 0,
+        SQLCE35 = 1,
+        SQLCE40 = 2,
+        SQLServer = 3,
+        SQLite = 4,
+        Npgsql = 5
     }
 }

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/ReverseEngineerOptions.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/ReverseEngineerOptions.cs
@@ -4,6 +4,9 @@ using System.Runtime.Serialization;
 
 namespace ReverseEngineer20
 {
+    using System;
+    using System.Linq;
+
     public class ReverseEngineerOptions
     {
         [IgnoreDataMember]
@@ -17,6 +20,67 @@ namespace ReverseEngineer20
         public bool UseFluentApiOnly { get; set; }
         public string ContextClassName { get; set; }
         public List<TableInformation> Tables { get; set; }
+        public bool UseDatabaseNames { get; set; }
+        public bool UseInflector { get; set; }
+        public bool IdReplace { get; set; }
+        public bool UseHandleBars { get; set; }
+        public bool IncludeConnectionString { get; set; }
+        public int SelectedToBeGenerated { get; set; }
+        [IgnoreDataMember]
+        public string Dacpac { get; set; }
+        [IgnoreDataMember]
+        public List<Schema> CustomReplacers { get; set; }
+        public string DefaultDacpacSchema { get; set; }
+
+        public static ReverseEngineerOptions FromV1(ReverseEngineerOptionsV1 v1)
+        {
+            if (v1 == null)
+                throw new ArgumentNullException(nameof(v1));
+
+            return new ReverseEngineerOptions
+            {
+                DatabaseType = v1.DatabaseType,
+                ConnectionString = v1.ConnectionString,
+                ProjectPath = v1.ProjectPath,
+                OutputPath = v1.OutputPath,
+                ProjectRootNamespace = v1.ProjectRootNamespace,
+                UseFluentApiOnly = v1.UseFluentApiOnly,
+                ContextClassName = v1.ContextClassName,
+                Tables = v1.Tables
+                           .Select(m =>
+                            {
+                                // Try to parse the strings
+                                TableInformation.TryParse(m, out var ti);
+                                return ti;
+                            })
+                           .Where(m => m != null) // Only select the table information that could be parsed
+                           .ToList(),
+                UseDatabaseNames = v1.UseDatabaseNames,
+                UseInflector = v1.UseInflector,
+                IdReplace = v1.IdReplace,
+                UseHandleBars = v1.UseHandleBars,
+                IncludeConnectionString = v1.IncludeConnectionString,
+                SelectedToBeGenerated = v1.SelectedToBeGenerated,
+                Dacpac = v1.Dacpac,
+                CustomReplacers = v1.CustomReplacers,
+                DefaultDacpacSchema = v1.DefaultDacpacSchema
+            };
+        }
+    }
+
+    public class ReverseEngineerOptionsV1
+    {
+        [IgnoreDataMember]
+        public DatabaseType DatabaseType { get; set; }
+        [IgnoreDataMember]
+        public string ConnectionString { get; set; }
+        [IgnoreDataMember]
+        public string ProjectPath { get; set; }
+        public string OutputPath { get; set; }
+        public string ProjectRootNamespace { get; set; }
+        public bool UseFluentApiOnly { get; set; }
+        public string ContextClassName { get; set; }
+        public List<string> Tables { get; set; }
         public bool UseDatabaseNames { get; set; }
         public bool UseInflector { get; set; }
         public bool IdReplace { get; set; }

--- a/src/GUI/ReverseEngineer20/ReverseEngineer/TableInformation.cs
+++ b/src/GUI/ReverseEngineer20/ReverseEngineer/TableInformation.cs
@@ -2,36 +2,43 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// A class holding a certain information about tables.
     /// </summary>
+    [DataContract]
     [DebuggerDisplay("{" + nameof(SafeFullName) + ",nq}")]
     public class TableInformation
     {
         /// <summary>
         /// Gets the schema name of the table.
         /// </summary>
-        public string Schema { get; }
+        [DataMember]
+        public string Schema { get; set; }
 
         /// <summary>
         /// Gets the table name.
         /// </summary>
-        public string Name { get; }
+        [DataMember]
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets whether a primary key exists for the table or not.
         /// </summary>
-        public bool HasPrimaryKey { get; }
+        [DataMember]
+        public bool HasPrimaryKey { get; set; }
 
         /// <summary>
         /// Gets the unsafe (unescaped) full name of the table.
         /// </summary>
+        [IgnoreDataMember]
         public string UnsafeFullName => $"{Schema}.{Name}";
 
         /// <summary>
         /// Gets the safe (escaped) full name of the table.
         /// </summary>
+        [IgnoreDataMember]
         public string SafeFullName => $"[{Schema}].[{Name}]";
 
         /// <summary>
@@ -96,6 +103,34 @@
             var schema = split[0];
             var name = split[1];
             return new TableInformation(schema, name, hasPrimaryKey);
+        }
+
+        /// <summary>
+        /// Tries to parse the given <paramref name="table"/> into a <see cref="TableInformation"/> instance.
+        /// </summary>
+        /// <param name="table">The table to parse.</param>
+        /// <param name="tableInformation">The parsed <see cref="TableInformation"/>, or <b>null</b>.</param>
+        /// <returns><b>True</b>, if the parsing was successful, otherwise <b>false</b>.</returns>
+        public static bool TryParse(string table,
+                                    out TableInformation tableInformation)
+        {
+            if (string.IsNullOrWhiteSpace(table))
+            {
+                tableInformation = null;
+                return false;
+            }
+            
+            var split = table.Split('.');
+            if (split.Length != 2)
+            {
+                tableInformation = null;
+                return false;
+            }
+
+            var schema = split[0];
+            var name = split[1];
+            tableInformation = new TableInformation(schema, name, true);
+            return true;
         }
     }
 }

--- a/src/GUI/UnitTests/Models/DatabaseConnectionModelTests.cs
+++ b/src/GUI/UnitTests/Models/DatabaseConnectionModelTests.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+
+namespace UnitTests.Models
+{
+    using EFCorePowerTools.Shared.Enums;
+    using EFCorePowerTools.Shared.Models;
+
+    [TestFixture]
+    public class DatabaseConnectionModelTests
+    {
+        [Test]
+        public void PropertyChanged_NotInvokedForEqualValues()
+        {
+            // Arrange
+            var invokes = 0;
+            var dcm = new DatabaseConnectionModel();
+            dcm.PropertyChanged += (sender, args) => invokes++;
+
+            // Act
+            dcm.ConnectionName = null;
+            dcm.ConnectionString = null;
+            dcm.DatabaseType = DatabaseType.Undefined;
+
+            // Assert
+            Assert.AreEqual(0, invokes);
+            Assert.IsNull(dcm.ConnectionName);
+            Assert.IsNull(dcm.ConnectionString);
+            Assert.AreEqual(DatabaseType.Undefined, dcm.DatabaseType);
+        }
+
+        [Test]
+        public void PropertyChanged_InvokedForDifferentValues()
+        {
+            // Arrange
+            var invokes = 0;
+            var dcm = new DatabaseConnectionModel();
+            dcm.PropertyChanged += (sender, args) => invokes++;
+            const string connectionName = "foobar";
+            const string connectionString = "Data Source=...;Initial Catalog=...;User=...;Password=...";
+            const DatabaseType dbType = DatabaseType.SQLite;
+
+            // Act
+            dcm.ConnectionName = connectionName;
+            dcm.ConnectionString = connectionString;
+            dcm.DatabaseType = dbType;
+
+            // Assert
+            Assert.AreEqual(3, invokes);
+            Assert.AreEqual(connectionName, dcm.ConnectionName);
+            Assert.AreEqual(connectionString, dcm.ConnectionString);
+            Assert.AreEqual(dbType, dcm.DatabaseType);
+        }
+    }
+}

--- a/src/GUI/UnitTests/Models/DatabaseDefinitionModelTests.cs
+++ b/src/GUI/UnitTests/Models/DatabaseDefinitionModelTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+
+namespace UnitTests.Models
+{
+    using EFCorePowerTools.Shared.Models;
+
+    [TestFixture]
+    public class DatabaseDefinitionModelTests
+    {
+        [Test]
+        public void PropertyChanged_NotInvokedForEqualValues()
+        {
+            // Arrange
+            var invokes = 0;
+            var ddm = new DatabaseDefinitionModel();
+            ddm.PropertyChanged += (sender, args) => invokes++;
+
+            // Act
+            ddm.FilePath = null;
+
+            // Assert
+            Assert.AreEqual(0, invokes);
+            Assert.IsNull(ddm.FilePath);
+        }
+
+        [Test]
+        public void PropertyChanged_InvokedForDifferentValues()
+        {
+            // Arrange
+            var invokes = 0;
+            var ddm = new DatabaseDefinitionModel();
+            ddm.PropertyChanged += (sender, args) => invokes++;
+            const string filePath = @"C:\Temp\Test\Database.dacpac";
+
+            // Act
+            ddm.FilePath = filePath;
+
+            // Assert
+            Assert.AreEqual(1, invokes);
+            Assert.AreEqual(filePath, ddm.FilePath);
+        }
+    }
+}

--- a/src/GUI/UnitTests/ReverseEngineer/TableInformationTest.cs
+++ b/src/GUI/UnitTests/ReverseEngineer/TableInformationTest.cs
@@ -138,7 +138,7 @@
 
             // Act
             var parsed1 = TableInformation.TryParse(table1, out var tableInformation1);
-            var parsed2 = TableInformation.TryParse(table1, out var tableInformation2);
+            var parsed2 = TableInformation.TryParse(table2, out var tableInformation2);
 
             // Assert
             Assert.IsFalse(parsed1);

--- a/src/GUI/UnitTests/ReverseEngineer/TableInformationTest.cs
+++ b/src/GUI/UnitTests/ReverseEngineer/TableInformationTest.cs
@@ -114,5 +114,55 @@
             Assert.AreEqual("dbo.Album", ti2.UnsafeFullName);
             Assert.AreEqual("[dbo].[Album]", ti2.SafeFullName);
         }
+
+        [Test]
+        public void TryParse_Empty()
+        {
+            // Arrange
+            string table = null;
+
+            // Act
+            var parsed = TableInformation.TryParse(table, out var tableInformation);
+
+            // Assert
+            Assert.IsFalse(parsed);
+            Assert.IsNull(tableInformation);
+        }
+
+        [Test]
+        public void TryParse_NotTwoPeriods()
+        {
+            // Arrange
+            var table1 = "Album";
+            var table2 = "[config.legacy].Album";
+
+            // Act
+            var parsed1 = TableInformation.TryParse(table1, out var tableInformation1);
+            var parsed2 = TableInformation.TryParse(table1, out var tableInformation2);
+
+            // Assert
+            Assert.IsFalse(parsed1);
+            Assert.IsFalse(parsed2);
+            Assert.IsNull(tableInformation1);
+            Assert.IsNull(tableInformation2);
+        }
+
+        [Test]
+        public void TryParse_OnlyTable_CorrectCreation()
+        {
+            // Arrange
+            var table = "dbo.Album";
+
+            // Act
+            var parsed = TableInformation.TryParse(table, out var ti);
+
+            // Assert
+            Assert.IsTrue(parsed);
+            Assert.AreEqual("dbo", ti.Schema);
+            Assert.AreEqual("Album", ti.Name);
+            Assert.IsTrue(ti.HasPrimaryKey);
+            Assert.AreEqual("dbo.Album", ti.UnsafeFullName);
+            Assert.AreEqual("[dbo].[Album]", ti.SafeFullName);
+        }
     }
 }

--- a/src/GUI/UnitTests/UnitTests.csproj
+++ b/src/GUI/UnitTests/UnitTests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="ReverseEngineer\TableInformationTest.cs" />
     <Compile Include="Services\ReplacingCandidateNamingServiceTests.cs" />
     <Compile Include="ViewModels\AboutViewModelTests.cs" />
+    <Compile Include="ViewModels\PickServerDatabaseViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\ErikEJ.EntityFrameworkCore.DgmlBuilder\template.dgml">

--- a/src/GUI/UnitTests/UnitTests.csproj
+++ b/src/GUI/UnitTests/UnitTests.csproj
@@ -163,6 +163,8 @@
     <Compile Include="BLL\InstalledComponentsServiceTests.cs" />
     <Compile Include="CheckListBoxTest.cs" />
     <Compile Include="Models\AboutExtensionModelTests.cs" />
+    <Compile Include="Models\DatabaseConnectionModelTests.cs" />
+    <Compile Include="Models\DatabaseDefinitionModelTests.cs" />
     <Compile Include="PluralizerTest.cs" />
     <Compile Include="DacpacTest.cs" />
     <Compile Include="PathHelperTest.cs" />

--- a/src/GUI/UnitTests/ViewModels/PickServerDatabaseViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/PickServerDatabaseViewModelTests.cs
@@ -3,6 +3,7 @@
 namespace UnitTests.ViewModels
 {
     using System;
+    using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.Shared.DAL;
     using EFCorePowerTools.Shared.Models;
     using EFCorePowerTools.ViewModels;
@@ -222,18 +223,24 @@ namespace UnitTests.ViewModels
             // Arrange
             var dbConnection = new DatabaseConnectionModel();
             var closeRequested = false;
+            bool? dialogResult = null;
             var vsa = Mock.Of<IVisualStudioAccess>();
             var vm = new PickServerDatabaseViewModel(vsa)
             {
                 SelectedDatabaseConnection = dbConnection
             };
-            vm.CloseRequested += (sender, args) => closeRequested = true;
+            vm.CloseRequested += (sender, args) =>
+            {
+                closeRequested = true;
+                dialogResult = args.DialogResult;
+            };
 
             // Act
             vm.OkCommand.Execute(null);
 
             // Assert
             Assert.IsTrue(closeRequested);
+            Assert.IsTrue(dialogResult);
             Assert.AreSame(dbConnection, vm.SelectedDatabaseConnection);
             Assert.IsNull(vm.SelectedDatabaseDefinition);
         }
@@ -244,18 +251,24 @@ namespace UnitTests.ViewModels
             // Arrange
             var dbDefinition = new DatabaseDefinitionModel();
             var closeRequested = false;
+            bool? dialogResult = null;
             var vsa = Mock.Of<IVisualStudioAccess>();
             var vm = new PickServerDatabaseViewModel(vsa)
             {
                 SelectedDatabaseDefinition = dbDefinition
             };
-            vm.CloseRequested += (sender, args) => closeRequested = true;
+            vm.CloseRequested += (sender, args) =>
+            {
+                closeRequested = true;
+                dialogResult = args.DialogResult;
+            };
 
             // Act
             vm.OkCommand.Execute(null);
 
             // Assert
             Assert.IsTrue(closeRequested);
+            Assert.IsTrue(dialogResult);
             Assert.AreSame(dbDefinition, vm.SelectedDatabaseDefinition);
             Assert.IsNull(vm.SelectedDatabaseConnection);
         }
@@ -280,18 +293,24 @@ namespace UnitTests.ViewModels
             // Arrange
             var dbConnection = new DatabaseConnectionModel();
             var closeRequested = false;
+            bool? dialogResult = null;
             var vsa = Mock.Of<IVisualStudioAccess>();
             var vm = new PickServerDatabaseViewModel(vsa)
             {
                 SelectedDatabaseConnection = dbConnection
             };
-            vm.CloseRequested += (sender, args) => closeRequested = true;
+            vm.CloseRequested += (sender, args) =>
+            {
+                closeRequested = true;
+                dialogResult = args.DialogResult;
+            };
 
             // Act
             vm.CancelCommand.Execute(null);
 
             // Assert
             Assert.IsTrue(closeRequested);
+            Assert.IsFalse(dialogResult);
             Assert.IsNull(vm.SelectedDatabaseConnection);
             Assert.IsNull(vm.SelectedDatabaseDefinition);
         }
@@ -302,18 +321,24 @@ namespace UnitTests.ViewModels
             // Arrange
             var dbDefinition = new DatabaseDefinitionModel();
             var closeRequested = false;
+            bool? dialogResult = null;
             var vsa = Mock.Of<IVisualStudioAccess>();
             var vm = new PickServerDatabaseViewModel(vsa)
             {
                 SelectedDatabaseDefinition = dbDefinition
             };
-            vm.CloseRequested += (sender, args) => closeRequested = true;
+            vm.CloseRequested += (sender, args) =>
+            {
+                closeRequested = true;
+                dialogResult = args.DialogResult;
+            };
 
             // Act
             vm.CancelCommand.Execute(null);
 
             // Assert
             Assert.IsTrue(closeRequested);
+            Assert.IsFalse(dialogResult);
             Assert.IsNull(vm.SelectedDatabaseConnection);
             Assert.IsNull(vm.SelectedDatabaseDefinition);
         }
@@ -358,6 +383,24 @@ namespace UnitTests.ViewModels
             // Assert
             Assert.IsNull(vm.SelectedDatabaseConnection);
             Assert.AreSame(dbDefinition, vm.SelectedDatabaseDefinition);
+        }
+
+        [Test]
+        public void PropertyChangedOnDatabaseDefinitionsChanged()
+        {
+            // Arrange
+            string propertyChangedName = null;
+            var dbDefinition = new DatabaseDefinitionModel();
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+            vm.PropertyChanged += (sender, args) => propertyChangedName = args.PropertyName;
+
+            // Act
+            vm.DatabaseDefinitions.Add(dbDefinition);
+
+            // Assert
+            Assert.IsNotNull(propertyChangedName);
+            Assert.AreEqual(nameof(IPickServerDatabaseViewModel.DatabaseDefinitions), propertyChangedName);
         }
     }
 }

--- a/src/GUI/UnitTests/ViewModels/PickServerDatabaseViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/PickServerDatabaseViewModelTests.cs
@@ -1,0 +1,363 @@
+﻿using NUnit.Framework;
+
+namespace UnitTests.ViewModels
+{
+    using System;
+    using EFCorePowerTools.Shared.DAL;
+    using EFCorePowerTools.Shared.Models;
+    using EFCorePowerTools.ViewModels;
+    using Moq;
+
+    [TestFixture]
+    public class PickServerDatabaseViewModelTests
+    {
+        [Test]
+        public void Constructor_ArgumentNullException()
+        {
+            // Arrange
+            IVisualStudioAccess vsa = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new PickServerDatabaseViewModel(vsa));
+        }
+
+        [Test]
+        public void Constructor_CommandsInitialized()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+
+            // Act
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Assert
+            Assert.IsNotNull(vm.LoadedCommand);
+            Assert.IsNotNull(vm.AddDatabaseConnectionCommand);
+            Assert.IsNotNull(vm.OkCommand);
+            Assert.IsNotNull(vm.CancelCommand);
+        }
+
+        [Test]
+        public void Constructor_CollectionsInitialized()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+
+            // Act
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Assert
+            Assert.IsNotNull(vm.DatabaseConnections);
+            Assert.IsNotNull(vm.DatabaseDefinitions);
+        }
+
+        [Test]
+        public void Constructor_NoSelection()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+
+            // Act
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Assert
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            Assert.IsNull(vm.SelectedDatabaseDefinition);
+        }
+
+        [Test]
+        public void LoadedCommand_CanExecute()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Act
+            var canExecute = vm.LoadedCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsTrue(canExecute);
+        }
+
+        [Test]
+        public void LoadedCommand_Executed()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+            var dbConnection1 = new DatabaseConnectionModel();
+            var dbConnection2 = new DatabaseConnectionModel();
+            vm.DatabaseConnections.Add(dbConnection1);
+            vm.DatabaseConnections.Add(dbConnection2);
+
+            // Act
+            vm.LoadedCommand.Execute(null);
+
+            // Assert
+            Assert.AreSame(dbConnection1, vm.SelectedDatabaseConnection);
+        }
+
+        [Test]
+        public void AddDatabaseConnectionCommand_CanExecute()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Act
+            var canExecute = vm.AddDatabaseConnectionCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsTrue(canExecute);
+        }
+
+        [Test]
+        public void AddDatabaseConnectionCommand_Executed_ExceptionDuringPrompt()
+        {
+            // Arrange
+            var vsaMock = new Mock<IVisualStudioAccess>();
+            vsaMock.Setup(m => m.PromptForNewDatabaseConnection()).Throws<InvalidOperationException>();
+            var vm = new PickServerDatabaseViewModel(vsaMock.Object);
+
+            // Act
+            vm.AddDatabaseConnectionCommand.Execute(null);
+
+            // Assert
+            CollectionAssert.IsEmpty(vm.DatabaseConnections);
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            vsaMock.Verify(m => m.PromptForNewDatabaseConnection(), Times.Once);
+            vsaMock.Verify(m => m.ShowMessage(It.IsNotNull<string>()), Times.Once);
+        }
+
+        [Test]
+        public void AddDatabaseConnectionCommand_Executed_NoConnectionReturned()
+        {
+            // Arrange
+            var vsaMock = new Mock<IVisualStudioAccess>();
+            vsaMock.Setup(m => m.PromptForNewDatabaseConnection()).Returns<DatabaseConnectionModel>(null);
+            var vm = new PickServerDatabaseViewModel(vsaMock.Object);
+
+            // Act
+            vm.AddDatabaseConnectionCommand.Execute(null);
+
+            // Assert
+            CollectionAssert.IsEmpty(vm.DatabaseConnections);
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            vsaMock.Verify(m => m.PromptForNewDatabaseConnection(), Times.Once);
+            vsaMock.Verify(m => m.ShowMessage(It.IsNotNull<string>()), Times.Never);
+        }
+
+        [Test]
+        public void AddDatabaseConnectionCommand_Executed_NewConnectionReturned()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var vsaMock = new Mock<IVisualStudioAccess>();
+            vsaMock.Setup(m => m.PromptForNewDatabaseConnection()).Returns(dbConnection);
+            var vm = new PickServerDatabaseViewModel(vsaMock.Object);
+
+            // Act
+            vm.AddDatabaseConnectionCommand.Execute(null);
+
+            // Assert
+            CollectionAssert.Contains(vm.DatabaseConnections, dbConnection);
+            Assert.AreSame(dbConnection, vm.SelectedDatabaseConnection);
+            vsaMock.Verify(m => m.PromptForNewDatabaseConnection(), Times.Once);
+            vsaMock.Verify(m => m.ShowMessage(It.IsNotNull<string>()), Times.Never);
+        }
+
+        [Test]
+        public void OkCommand_CanExecute_NothingSelected()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Act
+            var canExecute = vm.OkCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsFalse(canExecute);
+        }
+
+        [Test]
+        public void OkCommand_CanExecute_ConnectionSelected()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseConnection = dbConnection
+            };
+
+            // Act
+            var canExecute = vm.OkCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsTrue(canExecute);
+        }
+
+        [Test]
+        public void OkCommand_CanExecute_DefinitionSelected()
+        {
+            // Arrange
+            var dbDefinition = new DatabaseDefinitionModel();
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseDefinition = dbDefinition
+            };
+
+            // Act
+            var canExecute = vm.OkCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsTrue(canExecute);
+        }
+
+        [Test]
+        public void OkCommand_Executed_CloseRequestedToView_DatabaseConnection()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var closeRequested = false;
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseConnection = dbConnection
+            };
+            vm.CloseRequested += (sender, args) => closeRequested = true;
+
+            // Act
+            vm.OkCommand.Execute(null);
+
+            // Assert
+            Assert.IsTrue(closeRequested);
+            Assert.AreSame(dbConnection, vm.SelectedDatabaseConnection);
+            Assert.IsNull(vm.SelectedDatabaseDefinition);
+        }
+
+        [Test]
+        public void OkCommand_Executed_CloseRequestedToView_DatabaseDefinition()
+        {
+            // Arrange
+            var dbDefinition = new DatabaseDefinitionModel();
+            var closeRequested = false;
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseDefinition = dbDefinition
+            };
+            vm.CloseRequested += (sender, args) => closeRequested = true;
+
+            // Act
+            vm.OkCommand.Execute(null);
+
+            // Assert
+            Assert.IsTrue(closeRequested);
+            Assert.AreSame(dbDefinition, vm.SelectedDatabaseDefinition);
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+        }
+
+        [Test]
+        public void CancelCommand_CanExecute()
+        {
+            // Arrange
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa);
+
+            // Act
+            var canExecute = vm.CancelCommand.CanExecute(null);
+
+            // Assert
+            Assert.IsTrue(canExecute);
+        }
+
+        [Test]
+        public void CancelCommand_Executed_DatabaseConnection()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var closeRequested = false;
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseConnection = dbConnection
+            };
+            vm.CloseRequested += (sender, args) => closeRequested = true;
+
+            // Act
+            vm.CancelCommand.Execute(null);
+
+            // Assert
+            Assert.IsTrue(closeRequested);
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            Assert.IsNull(vm.SelectedDatabaseDefinition);
+        }
+
+        [Test]
+        public void CancelCommand_Executed_DatabaseDefinition()
+        {
+            // Arrange
+            var dbDefinition = new DatabaseDefinitionModel();
+            var closeRequested = false;
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseDefinition = dbDefinition
+            };
+            vm.CloseRequested += (sender, args) => closeRequested = true;
+
+            // Act
+            vm.CancelCommand.Execute(null);
+
+            // Assert
+            Assert.IsTrue(closeRequested);
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            Assert.IsNull(vm.SelectedDatabaseDefinition);
+        }
+
+        [Test]
+        public void Selection_OnlyConnectionOrDefinitionSelected_DatabaseConnection()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var dbDefinition = new DatabaseDefinitionModel();
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            // ReSharper disable once UseObjectOrCollectionInitializer
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseDefinition = dbDefinition
+            };
+
+            // Act
+            vm.SelectedDatabaseConnection = dbConnection;
+
+            // Assert
+            Assert.IsNull(vm.SelectedDatabaseDefinition);
+            Assert.AreSame(dbConnection, vm.SelectedDatabaseConnection);
+        }
+
+        [Test]
+        public void Selection_OnlyConnectionOrDefinitionSelected_DatabaseDefinition()
+        {
+            // Arrange
+            var dbConnection = new DatabaseConnectionModel();
+            var dbDefinition = new DatabaseDefinitionModel();
+            var vsa = Mock.Of<IVisualStudioAccess>();
+            // ReSharper disable once UseObjectOrCollectionInitializer
+            var vm = new PickServerDatabaseViewModel(vsa)
+            {
+                SelectedDatabaseConnection = dbConnection
+            };
+
+            // Act
+            vm.SelectedDatabaseDefinition = dbDefinition;
+
+            // Assert
+            Assert.IsNull(vm.SelectedDatabaseConnection);
+            Assert.AreSame(dbDefinition, vm.SelectedDatabaseDefinition);
+        }
+    }
+}


### PR DESCRIPTION
For #116 

### PR summary
#### Commit 1 (1b77674)
- Added database connection model to hold information about a database connection
- Added database definition model to hold information about a database definition (database project or dacpac)
- Added unit tests for the new models
- Added shared enum DatabaseType

#### Commit 2 (3280b27)
- Replaced the DatabaseType enum in `EFCorePowerTools` with the shared enum from commit 1
- Synced enum in ReverseEngineer (**Note: there's always the risk that those enums won't match at any point in time, if somebody forgets to update both**)

#### Commit 3 (9e1f6ee)
- Implemented ViewModel for the PickServerDatabase dialog
- Added unit tests for the new ViewModel

#### Commit 4 (86758b8)
- Refactored the actual dialog (*.xaml and *.xaml.cs) by implementing the view model