### PR TITLE
UI improvements for PickTablesDialog

### DIFF
--- a/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
@@ -3,11 +3,11 @@
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  xmlns:extToolkit="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit"
-                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:viewModels="clr-namespace:EFCorePowerTools.ViewModels"
                  xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                 mc:Ignorable="d" 
+                 mc:Ignorable="d"
                  Title="Select Tables to Script"
                  ShowInTaskbar="False"
                  Height="455.056"
@@ -25,8 +25,28 @@
     <dw:DialogWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Converter.xaml"/>
-                <ResourceDictionary Source="Style.xaml"/>
+                <ResourceDictionary Source="Converter.xaml" />
+                <ResourceDictionary Source="Style.xaml" />
+                <ResourceDictionary>
+                    <Style x:Key="TableSelectionCheckBoxStyle" TargetType="CheckBox">
+                        <Setter Property="Margin" Value="0, 0, 5, 0"/>
+                    </Style>
+                    <Style x:Key="NoPrimaryKeyImageStyle" TargetType="Image">
+                        <Setter Property="ToolTip" Value="No primary key defined. Table will be ignored."/>
+                        <Setter Property="Source" Value="/EFCorePowerTools;component/Resources/StatusInvalid_16x.png"/>
+                        <Setter Property="Width" Value="16"/>
+                        <Setter Property="Height" Value="16"/>
+                        <Setter Property="Margin" Value="5, 0, 0, 0"/>
+                    </Style>
+                    <Style x:Key="TableNameTextBlockStyle" TargetType="TextBlock"
+                           d:DataContext="{d:DesignInstance Type=viewModels:TableInformationViewModel, IsDesignTimeCreatable=false}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Model.HasPrimaryKey}" Value="False">
+                                <Setter Property="Foreground" Value="{StaticResource DisabledTextBlockTextColor}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </dw:DialogWindow.Resources>
@@ -37,14 +57,14 @@
 
     <Grid>
         <StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="6,6,6,3" Width="390" >
+            <StackPanel Orientation="Horizontal" Margin="6,6,6,3" Width="390">
                 <dw:DialogButton ToolTip="Save the seletion of tables."
                                  Margin="178,0,0,0"
                                  Content="Save Selection"
                                  Width="102"
                                  MinWidth="20"
                                  Height="10"
-                                 Command="{Binding SaveSelectionCommand}"/>
+                                 Command="{Binding SaveSelectionCommand}" />
                 <dw:DialogButton ToolTip="Load a selection of tables."
                                  Margin="3,0,0,0"
                                  Content="Load Selection"
@@ -53,21 +73,21 @@
                                  Height="23"
                                  MinWidth="20"
                                  HorizontalAlignment="Left"
-                                 Command="{Binding LoadSelectionCommand}"/>
+                                 Command="{Binding LoadSelectionCommand}" />
             </StackPanel>
 
             <StackPanel Orientation="Horizontal"
                         Margin="6,0,6,6"
-                        Width="390" >
+                        Width="390">
                 <CheckBox Content="Tables"
                           IsChecked="{Binding TableSelectionThreeState}"
                           Margin="10,0,0,0"
                           BorderThickness="2"
                           IsThreeState="True"
-                          VerticalAlignment="Center"/>
+                          VerticalAlignment="Center" />
                 <Label Content="Search"
                        Margin="43,0,0,0"
-                       Width="47"/>
+                       Width="47" />
                 <TextBox ToolTip="Search for table"
                          Height="22"
                          TextWrapping="Wrap"
@@ -75,30 +95,27 @@
                          Margin="0,0,5,0"
                          Background="White"
                          Foreground="Black"
-                         Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                         Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
 
-            <!-- Do not remove the name of the extToolkit:CheckListBox: https://stackoverflow.com/a/41605335/2132796 -->
-            <extToolkit:CheckListBox x:Name="TableSelectionCheckListBox"
-                                     Margin="12,0"
-                                     SelectedMemberPath="IsSelected"
-                                     Height="302"
-                                     ItemsSource="{Binding FilteredTables}">
-                <extToolkit:CheckListBox.ItemTemplate>
+            <ListBox Margin="12,0"
+                     Height="302"
+                     ItemsSource="{Binding FilteredTables}">
+                <ListBox.ItemTemplate>
                     <DataTemplate>
-                       <StackPanel Orientation="Horizontal"
-                                   d:DataContext="{d:DesignInstance Type=viewModels:TableInformationViewModel, IsDesignTimeCreatable=false}">
-                           <TextBlock Text="{Binding Model.UnsafeFullName}"/>
-                            <Image Visibility="{Binding Model.HasPrimaryKey, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=invert}"
-                                   Width="16"
-                                   Height="16"
-                                   Margin="5, 0, 0, 0"
-                                   Source="/EFCorePowerTools;component/Resources/StatusInvalid_16x.png"
-                                   ToolTip="No primary key defined. Table will be ignored."/>
+                        <StackPanel Orientation="Horizontal"
+                                    d:DataContext="{d:DesignInstance Type=viewModels:TableInformationViewModel, IsDesignTimeCreatable=false}">
+                            <CheckBox Style="{StaticResource TableSelectionCheckBoxStyle}"
+                                      IsChecked="{Binding IsSelected}"
+                                      IsEnabled="{Binding Model.HasPrimaryKey}"/>
+                            <TextBlock Text="{Binding Model.UnsafeFullName}" 
+                                       Style="{StaticResource TableNameTextBlockStyle}"/>
+                            <Image Style="{StaticResource NoPrimaryKeyImageStyle}"
+                                   Visibility="{Binding Model.HasPrimaryKey, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=invert}"/>
                         </StackPanel>
                     </DataTemplate>
-                </extToolkit:CheckListBox.ItemTemplate>
-            </extToolkit:CheckListBox>
+                </ListBox.ItemTemplate>
+            </ListBox>
 
             <StackPanel Orientation="Horizontal">
                 <dw:DialogButton Content="OK"
@@ -106,7 +123,7 @@
                                  Margin="230,12,12,12"
                                  TabIndex="6"
                                  Width="75"
-                                 Command="{Binding OkCommand}"/>
+                                 Command="{Binding OkCommand}" />
                 <dw:DialogButton Content="Cancel"
                                  IsCancel="True"
                                  HorizontalAlignment="Right"
@@ -115,7 +132,7 @@
                                  SnapsToDevicePixels="False"
                                  Height="23"
                                  VerticalAlignment="Bottom"
-                                 Command="{Binding CancelCommand}"/>
+                                 Command="{Binding CancelCommand}" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/src/GUI/EFCorePowerTools/Dialogs/Style.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/Style.xaml
@@ -9,5 +9,6 @@
     </Style>
 
     <SolidColorBrush x:Key="DialogWindowBackgroundColor" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="DisabledTextBlockTextColor" Color="#FF707070"/>
 
 </ResourceDictionary>


### PR DESCRIPTION
This improvements replace the Xceed control with the default Windows control, allowing more flexibility on the UI.

### Before
![grafik](https://user-images.githubusercontent.com/651191/49608114-266fb380-f998-11e8-893b-cb5fdf7f3cc3.png)

### After
![grafik](https://user-images.githubusercontent.com/651191/49608108-21aaff80-f998-11e8-9dfb-48c6e58354c2.png)
