### PR TITLE
Bugfix for pick server / database dialog

### DIFF
--- a/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
+++ b/src/GUI/EFCorePowerTools/Helpers/EnvDTEHelper.cs
@@ -120,16 +120,18 @@ namespace ErikEJ.SqlCeToolbox.Helpers
             var info = GetDatabaseInfo(package, dialogResult.Provider, DataProtection.DecryptString(dialog.EncryptedConnectionString));
             if (info.Size == Guid.Empty.ToString()) return new DatabaseInfo { DatabaseType = DatabaseType.Undefined };
 
-            SaveDataConnection(package, dialog.EncryptedConnectionString, info.DatabaseType, new Guid(info.Size));
+            var savedName = SaveDataConnection(package, dialog.EncryptedConnectionString, info.DatabaseType, new Guid(info.Size));
+            info.Caption = savedName;
             return info;
         }
 
-        internal static void SaveDataConnection(EFCorePowerToolsPackage package, string encryptedConnectionString,
+        internal static string SaveDataConnection(EFCorePowerToolsPackage package, string encryptedConnectionString,
             DatabaseType dbType, Guid provider)
         {
             var dataExplorerConnectionManager = package.GetService<IVsDataExplorerConnectionManager>();
             var savedName = GetFileName(DataProtection.DecryptString(encryptedConnectionString), dbType);
             dataExplorerConnectionManager.AddConnection(savedName, provider, encryptedConnectionString, true);
+            return savedName;
         }
 
         private static DatabaseInfo GetDatabaseInfo(EFCorePowerToolsPackage package, Guid provider, string connectionString)


### PR DESCRIPTION
Adding a new connection via the 'Add...' wouldn't display anything in the ComboBox after adding a new conneciton. There would be an entry, but without any text. Those entries were however displayed correctly when opening the dialog again.

This fix resolves the issue, by keeping the display name throughout the layers.