### PR TITLE
Updated README (badge, https, 2019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 Entity Framework Core Power Tools - reverse engineering and model visualization for EF Core
 
 [![Gitter](https://badges.gitter.im/EFCorePowerTools/community.svg)](https://gitter.im/EFCorePowerTools/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Visual Studio Marketplace Version](https://vsmarketplacebadge.apphb.com/version/ErikEJ.EFCorePowerTools.svg)](https://marketplace.visualstudio.com/items?itemName=ErikEJ.EFCorePowerTools)
 
-[![Twitter Follow](https://img.shields.io/twitter/follow/ErikEJ.svg?style=social&label=Follow)](http://twitter.com/ErikEJ) 
+[![Twitter Follow](https://img.shields.io/twitter/follow/ErikEJ.svg?style=social&label=Follow)](https://twitter.com/ErikEJ) 
 
 [EF Core Power Tools presentation](https://erikej.github.io/EFCorePowerTools/index.html)
 
-[My tools and utilities for embedded database development](http://erikej.github.io/SqlCeToolbox/)
+[My tools and utilities for embedded database development](https://erikej.github.io/SqlCeToolbox/)
 
 If you use my free tools, I would be very grateful for a [rating or review here](https://marketplace.visualstudio.com/items?itemName=ErikEJ.EFCorePowerTools#review-details)
 
@@ -22,7 +23,7 @@ The EF Core Power Tools contains DbContext design time feature: Reverse Engineer
 
 **Release**
 
-Download the latest version of the Visual Studio 2017 extension from [Visual Studio MarketPlace](https://marketplace.visualstudio.com/items?itemName=ErikEJ.EFCorePowerTools)
+Download the latest version of the extension from [Visual Studio MarketPlace](https://marketplace.visualstudio.com/items?itemName=ErikEJ.EFCorePowerTools)
 
 Or just install from Tools, Extensions and Updates in Visual Studio! ![](https://github.com/ErikEJ/SqlCeToolbox/blob/master/img/ext.png)
 
@@ -31,7 +32,7 @@ Or just install from Tools, Extensions and Updates in Visual Studio! ![](https:/
 You can download the daily build from [VSIX Gallery](http://vsixgallery.com/extensions/f4c4712c-ceae-4803-8e52-0e2049d5de9f/extension.vsix)
 
 You can also use this **Feed URL**: 
-[http://vsixgallery.com/feed/extension/f4c4712c-ceae-4803-8e52-0e2049d5de9f](http://vsixgallery.com/feed/extension/f4c4712c-ceae-4803-8e52-0e2049d5de9f) 
+[http://vsixgallery.com/feed/extension/f4c4712c-ceae-4803-8e52-0e2049d5de9f](https://vsixgallery.com/feed/extension/f4c4712c-ceae-4803-8e52-0e2049d5de9f) 
 
 following [these instructions to automatically get the latest build of the Master branch directly in Visual Studio](https://github.com/ErikEJ/SqlCeToolbox/wiki/Subscribing-to-latest-%22daily%22-build)
 


### PR DESCRIPTION
- Added VS marketplace badge
- change http links to https (where possible)
- remove "Visual Studio 2017", as it also works for 2019

live preview: https://github.com/304NotModified/EFCorePowerTools/blob/patch-1/README.md