### PR TITLE
Fix for case 2 in #274

### DIFF
--- a/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacConsolidator.cs
+++ b/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacConsolidator.cs
@@ -39,8 +39,8 @@ namespace ReverseEngineer20.DacpacConsolidate
             var parser = new HeaderParser(dacpacPath);
 
             var references = parser.GetCustomData()
-                                   .Where(p => p.Category == "Reference" && p.Type == "SqlSchema")
-                                   .ToList();
+                .Where(p => p.Category == "Reference" && p.Type == "SqlSchema")
+                .ToList();
 
             if (references.Count == 0)
             {


### PR DESCRIPTION
parser.GetCustomData() throws FileNotFoundException for missing DACPACs.

The FileNotFoundException is OK if the reference of the root DACPAC is not found.
It is however not OK if the missing DACPAC is only referenced by another DACPAC than the root DACPAC, but not by the root DACPAC directly.
Therefore, skip missing DACPACs if they're not directly referenced by the root DACPAC.