### PR TITLE
Stability improvements and developer help

### DIFF
--- a/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacConsolidator.cs
+++ b/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacConsolidator.cs
@@ -54,6 +54,14 @@ namespace ReverseEngineer20.DacpacConsolidate
                 .Select(i => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(dacpacPath), i.Value)))
                 .ToList();
 
+            if (!isRootDacpac)
+            {
+                // If we're looking for references of a non-root DACPAC,
+                // any reference is optional (see SuppressMissingDependenciesErrors = true).
+                // Therefore this DACPACs won't be included, if they don't exist in the build output directory.
+                fileNames = fileNames.Where(File.Exists).ToList();
+            }
+
             if (fileNames.Count() == 0)
             {
                 return Enumerable.Empty<string>().ToList();

--- a/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacMerger.cs
+++ b/src/GUI/ReverseEngineer20/DacpacConsolidate/DacpacMerger.cs
@@ -93,7 +93,16 @@ namespace ReverseEngineer20.DacpacConsolidate
                 return _first;
             }
 
-            return new TSqlModel(source);
+            try
+            {
+                return new TSqlModel(source);
+            }
+            catch (DacModelException e) when (e.Message.Contains("Required references are missing."))
+            {
+                throw new DacModelException("Failed to load model from DACPAC. "
+                    + "A reason might be that the \"SuppressMissingDependenciesErrors\" isn't set to true consitenty. ",
+                    e);
+            }
         }
 
         private void AddScripts(string pre, string post, string dacpacPath)


### PR DESCRIPTION
Follow-up to #274 and #369 

Stability Improvements:
- MAJOR: If a referenced DACPAC points to other DACPACs, and those DACPACs don't exist in the build output of our main project, it was included in the additional files. With this change, missing third-level DACPACs won't be included in the final reference list.
- MINOR: While building, the last write time might exceed two seconds, but the file was still built correctly. Validate against the build start time instead.
- MINOR: Accessing project.FullName might throw a NotImplementedException (from COM). In that case, the best match we can find is using the UniqueName.

Improved developer help:
- Added additional exception information for missing required references. This issues might be caused by an inconsistent usage of SuppressMissingDependenciesErrors in the database projects. The improved error message will point out that this might be the reason for the exception.