### PR TITLE
Fixed #400

### DIFF
--- a/src/GUI/EFCorePowerTools/Contracts/ViewModels/IModelingOptionsViewModel.cs
+++ b/src/GUI/EFCorePowerTools/Contracts/ViewModels/IModelingOptionsViewModel.cs
@@ -10,7 +10,6 @@
     {
         event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
-        ICommand LoadedCommand { get; }
         ICommand OkCommand { get; }
         ICommand CancelCommand { get; }
 

--- a/src/GUI/EFCorePowerTools/Dialogs/EfCoreModelDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/EfCoreModelDialog.xaml
@@ -5,7 +5,6 @@
                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:viewModels="clr-namespace:EFCorePowerTools.ViewModels"
-                 xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
                  mc:Ignorable="d"
                  ShowInTaskbar="False"
                  MinHeight="680"
@@ -15,12 +14,6 @@
                  SizeToContent="WidthAndHeight"
                  d:DataContext="{d:DesignInstance Type=viewModels:ModelingOptionsViewModel, IsDesignTimeCreatable=False}"
                  Title="{Binding Title, Mode=OneWay}">
-
-    <i:Interaction.Triggers>
-        <i:EventTrigger EventName="Loaded">
-            <i:InvokeCommandAction Command="{Binding LoadedCommand}" />
-        </i:EventTrigger>
-    </i:Interaction.Triggers>
 
     <dw:DialogWindow.Resources>
         <ResourceDictionary>

--- a/src/GUI/EFCorePowerTools/ViewModels/ModelingOptionsViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/ModelingOptionsViewModel.cs
@@ -19,7 +19,6 @@
 
         public event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
-        public ICommand LoadedCommand { get; }
         public ICommand OkCommand { get; }
         public ICommand CancelCommand { get; }
 
@@ -55,7 +54,6 @@
             Title = string.Empty;
             MayIncludeConnectionString = true;
 
-            LoadedCommand = new RelayCommand(Loaded_Executed);
             OkCommand = new RelayCommand(Ok_Executed);
             CancelCommand = new RelayCommand(Cancel_Executed);
 
@@ -72,11 +70,6 @@
                 "C#",
                 "TypeScript"
             };
-        }
-
-        private void Loaded_Executed()
-        {
-            Model.SelectedToBeGenerated = 0;
         }
 
         private void Ok_Executed()


### PR DESCRIPTION
`Loaded` command was triggered after `ApplyPresets`, therefore overwriting the saved presets.