### PR TITLE
Add Type Name for Table Valued Parameters 

### DIFF
--- a/src/GUI/RevEng.Core/Procedures/Model/Metadata/ProcedureParameter.cs
+++ b/src/GUI/RevEng.Core/Procedures/Model/Metadata/ProcedureParameter.cs
@@ -9,6 +9,8 @@
         public byte? Scale { get; set; }
         public int Ordinal { get; set; }
         public bool Output { get; set; }
-        public bool Nullable { get; set; }        
+        public bool Nullable { get; set; }
+        public string TypeName { get; set; }
+        
     }
 }

--- a/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureModelFactory.cs
+++ b/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureModelFactory.cs
@@ -100,7 +100,8 @@ SELECT
                     case when system_type_id in (35, 99, 167, 175, 231, 239)  
                     then ServerProperty('collation') end),
     is_output AS output,
-	is_nullable AS nullable
+	is_nullable AS nullable,
+    'TypeName' = QUOTENAME(OBJECT_SCHEMA_NAME(object_id)) + '.' + QUOTENAME(TYPE_NAME(user_type_id))
     from sys.parameters where object_id = object_id('{schema}.{name}')
     ORDER BY parameter_id;";
 
@@ -123,6 +124,7 @@ SELECT
                     Ordinal = int.Parse(par["Order"].ToString()),
                     Output = (bool)par["output"],
                     Nullable = (bool)par["nullable"],
+                    TypeName = par["TypeName"].ToString()
                 };
 
                 result.Add(parameter);

--- a/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -266,7 +266,7 @@ namespace RevEng.Core.Procedures
 
                 if (parameter.DbType() == System.Data.SqlDbType.Structured)
                 {
-                    _sb.AppendLine($"TypeName = {parameter.TypeName},");
+                    _sb.AppendLine($"TypeName = \"{parameter.TypeName}\",");
                 }
             }
 

--- a/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -263,6 +263,11 @@ namespace RevEng.Core.Procedures
 
                 _sb.AppendLine($"SqlDbType = System.Data.SqlDbType.{parameter.DbType()},");
                 _sb.AppendLine($"Value = {parameter.Name},");
+
+                if (parameter.DbType() == System.Data.SqlDbType.Structured)
+                {
+                    _sb.AppendLine($"TypeName = {parameter.TypeName},");
+                }
             }
 
             _sb.AppendLine("};");


### PR DESCRIPTION
Addresses and issue where an exception is throw when executing a stored procedure that has been scaffolded containing a table valued parameter.

**Exception**

```
System.ArgumentException
  HResult=0x80070057
  Message=The table type parameter 'Shipments' must have a valid type name.
  Source=Microsoft.Data.SqlClient
  StackTrace:
   at Microsoft.Data.SqlClient.SqlCommand.<>c.<ExecuteDbDataReaderAsync>b__164_0(Task`1 result)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.<ExecuteReaderAsync>d__17.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.<ExecuteReaderAsync>d__17.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.<ExecuteReaderAsync>d__17.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryingEnumerable`1.AsyncEnumerator.<InitializeReaderAsync>d__18.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at Microsoft.EntityFrameworkCore.Storage.ExecutionStrategy.<ExecuteImplementationAsync>d__31`2.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.EntityFrameworkCore.Storage.ExecutionStrategy.<ExecuteImplementationAsync>d__31`2.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryingEnumerable`1.AsyncEnumerator.<MoveNextAsync>d__17.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.<ToListAsync>d__64`1.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.<ToListAsync>d__64`1.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.<ToArrayAsync>d__65`1.MoveNext()
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at DbContextExtensions.<SqlQuery>d__0`1.MoveNext() in C:\Source\Repos\StoredProcScaffold\TableAndChairs\Furniture.Shop\Data\DbContextExtensions.cs:line 14
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Furniture.Shop.Data.FurnitureContextProcedures.<GetShipments>d__2.MoveNext() in C:\Source\Repos\StoredProcScaffold\TableAndChairs\Furniture.Shop\Data\FurnitureContextProcedures.cs:line 29
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Furniture.Shop.Program.<Main>d__0.MoveNext() in C:\Source\Repos\StoredProcScaffold\TableAndChairs\Furniture.Shop\Program.cs:line 26

  This exception was originally thrown at this call stack:
    [External Code]
    DbContextExtensions.SqlQuery<T>(Microsoft.EntityFrameworkCore.DbContext, string, object[]) in DbContextExtensions.cs
    [External Code]
    Furniture.Shop.Data.FurnitureContextProcedures.GetShipments(System.Data.DataTable) in FurnitureContextProcedures.cs
    [External Code]
    Furniture.Shop.Program.Main(string[]) in Program.cs
```