### PR TITLE
New option to tell the reverse engineering process to create non nullable boolean properties only

### DIFF
--- a/src/GUI/EFCorePowerTools.Shared/Models/ModelingOptionsModel.cs
+++ b/src/GUI/EFCorePowerTools.Shared/Models/ModelingOptionsModel.cs
@@ -30,6 +30,7 @@
         private bool _mapSpatialTypes;
         private bool _mapNodaTimeTypes;
         private bool _useEf6Pluralizer;
+        private bool _generateNonNullableBoolsOnly;
 
         public bool UseDataAnnotations
         {
@@ -258,6 +259,17 @@
             {
                 if (value == _useEf6Pluralizer) return;
                 _useEf6Pluralizer = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool GenerateNonNullableBoolsOnly
+        {
+            get => _generateNonNullableBoolsOnly;
+            set
+            {
+                if (value == _generateNonNullableBoolsOnly) return;
+                _generateNonNullableBoolsOnly = value;
                 OnPropertyChanged();
             }
         }

--- a/src/GUI/EFCorePowerTools/Dialogs/AdvancedModelingOptionsDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/AdvancedModelingOptionsDialog.xaml
@@ -68,6 +68,11 @@
                       Content="Use EF6 pluralizer"
                       IsChecked="{Binding Model.UseEf6Pluralizer}" 
                       Style="{StaticResource MarginCheckBlockStyle}"/>
+
+            <CheckBox TabIndex="5"
+                      Content="Always generate non nullable bools"
+                      IsChecked="{Binding Model.GenerateNonNullableBoolsOnly}" 
+                      Style="{StaticResource MarginCheckBlockStyle}"/>
         </StackPanel>
 
         <StackPanel Grid.Row="20"

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
@@ -51,7 +51,7 @@
         <Parent guid="guidDbContextPackageCmdSet" id="cmdidEdmMenuGroup" />
         <Strings>
           <CommandName>EF Core Power Tools</CommandName>
-          <ButtonText>EF Core Power Tools</ButtonText>
+          <ButtonText>EF Core Power Tools (SF)</ButtonText>
         </Strings>
       </Menu>
 
@@ -65,7 +65,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidReverseEngineerCodeFirst</CommandName>
-          <ButtonText>Reverse Engineer</ButtonText>
+          <ButtonText>Reverse Engineer (SF)</ButtonText>
         </Strings>
       </Button>
 

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
@@ -51,7 +51,7 @@
         <Parent guid="guidDbContextPackageCmdSet" id="cmdidEdmMenuGroup" />
         <Strings>
           <CommandName>EF Core Power Tools</CommandName>
-          <ButtonText>EF Core Power Tools (SF)</ButtonText>
+          <ButtonText>EF Core Power Tools</ButtonText>
         </Strings>
       </Menu>
 
@@ -65,7 +65,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>cmdidReverseEngineerCodeFirst</CommandName>
-          <ButtonText>Reverse Engineer (SF)</ButtonText>
+          <ButtonText>Reverse Engineer</ButtonText>
         </Strings>
       </Button>
 

--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineer/ReverseEngineerOptions.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineer/ReverseEngineerOptions.cs
@@ -42,6 +42,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
         public bool UseStoredProcedures { get; set; }
         public bool FilterSchemas { get; set; }
         public List<SchemaInfo> Schemas { get; set; }
+        public bool GenerateNonNullableBoolsOnly { get; set; }
 
         public static ReverseEngineerOptions FromV1(ReverseEngineerOptionsV1 v1)
         {

--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
@@ -173,6 +173,7 @@ namespace EFCorePowerTools.Handlers
                     presets.UseEf6Pluralizer = options.UseLegacyPluralizer;
                     presets.MapSpatialTypes = options.UseSpatial;
                     presets.MapNodaTimeTypes = options.UseNodaTime;
+                    presets.GenerateNonNullableBoolsOnly = options.GenerateNonNullableBoolsOnly;
                 }
 
                 var modelDialog = _package.GetView<IModelingOptionsDialog>()
@@ -211,7 +212,8 @@ namespace EFCorePowerTools.Handlers
                     Tables = pickTablesResult.Payload.ToList(),
                     CustomReplacers = customNameOptions,
                     FilterSchemas = filterSchemas,
-                    Schemas = schemas?.ToList()
+                    Schemas = schemas?.ToList(),
+                    GenerateNonNullableBoolsOnly = modelingOptionsResult.Payload.GenerateNonNullableBoolsOnly
                 };
 
                 _package.Dte2.StatusBar.Text = "Generating code...";
@@ -383,6 +385,7 @@ namespace EFCorePowerTools.Handlers
                 UseDbContextSplitting = options.UseDbContextSplitting,
                 UseNodaTime = options.UseNodaTime,
                 UseStoredProcedures = options.UseStoredProcedures,
+                GenerateNonNullableBoolsOnly = options.GenerateNonNullableBoolsOnly
             };
 
             var launcher = new ReverseEngineer20.ReverseEngineer.EfRevEngLauncher(commandOptions, useEFCore5);

--- a/src/GUI/EFCorePowerTools/ViewModels/AdvancedModelingOptionsViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/AdvancedModelingOptionsViewModel.cs
@@ -58,6 +58,7 @@
             Model.MapSpatialTypes = presets.MapSpatialTypes;
             Model.MapNodaTimeTypes = presets.MapNodaTimeTypes;
             Model.UseEf6Pluralizer = presets.UseEf6Pluralizer;
+            Model.GenerateNonNullableBoolsOnly = presets.GenerateNonNullableBoolsOnly;
         }
     }
 }

--- a/src/GUI/EFCorePowerTools/ViewModels/ModelingOptionsViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/ModelingOptionsViewModel.cs
@@ -134,6 +134,7 @@ namespace EFCorePowerTools.ViewModels
             Model.MapSpatialTypes = advancedModelingOptionsResult.Payload.MapSpatialTypes;
             Model.MapNodaTimeTypes = advancedModelingOptionsResult.Payload.MapNodaTimeTypes;
             Model.UseEf6Pluralizer = advancedModelingOptionsResult.Payload.UseEf6Pluralizer;
+            Model.GenerateNonNullableBoolsOnly = advancedModelingOptionsResult.Payload.GenerateNonNullableBoolsOnly;
         }
 
         void IModelingOptionsViewModel.ApplyPresets(ModelingOptionsModel presets)
@@ -159,6 +160,7 @@ namespace EFCorePowerTools.ViewModels
             Model.MapSpatialTypes = presets.MapSpatialTypes;
             Model.MapNodaTimeTypes = presets.MapNodaTimeTypes;
             Model.UseEf6Pluralizer = presets.UseEf6Pluralizer;
+            Model.GenerateNonNullableBoolsOnly = presets.GenerateNonNullableBoolsOnly;
 
             Title = $"Generate EF Core Model in Project {Model.ProjectName}";
         }

--- a/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
+++ b/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
@@ -192,7 +192,6 @@ namespace ReverseEngineer20.ReverseEngineer
         private void PostProcessModel(string modelFile, ReverseEngineerCommandOptions options)
         {
             var finalLines = new List<string>();
-            var debugLines = new List<string>();
             var lines = File.ReadAllLines(modelFile);
 
             int i = 1;

--- a/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
+++ b/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
@@ -34,5 +34,6 @@ namespace ReverseEngineer20
         public bool UseStoredProcedures { get; set; }
         public bool FilterSchemas { get; set; }
         public List<SchemaInfo> Schemas { get; set; }
+        public bool GenerateNonNullableBoolsOnly { get; set; }
     }
 }


### PR DESCRIPTION
Added a new option GenerateNonNullableBoolsOnly (located in the AdvancedModelingOptionsDialog) to tell the reverse engineering process to create non nullable boolean properties only, no matter what kind of default value is specified for the bit column in the database.

If this option is set, each not nullable bit column with a sql default value other than 0 is mapped as:

```csharp
public bool IsActive { get; set; }
```

instead of:

```csharp
[Required]
public bool? IsActive { get; set; }
```

If there is no default value or a value of 0 specified, the scaffolder already generates public bool IsActive { get; set; }.

I think, there could a bunch of people which will like this option.