### PR TITLE
Adds ability to exclude columns from mapping during reveng

### DIFF
--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
@@ -148,12 +148,13 @@ namespace EFCorePowerTools.Handlers
                     }
                 }
 
-                for (var i = 0; i < predefinedTables.Count; i++)
-                {
-                    var preselectedTable = preselectedTables.FirstOrDefault(c => c.Name.Equals(predefinedTables[i].Name, StringComparison.OrdinalIgnoreCase));
-                    if (preselectedTable != null)
-                        predefinedTables[i] = preselectedTable;
-                }
+                //TODO: check if there's a better way to not erase excluded columns.
+                //for (var i = 0; i < predefinedTables.Count; i++)
+                //{
+                //    var preselectedTable = preselectedTables.FirstOrDefault(c => c.Name.Equals(predefinedTables[i].Name, StringComparison.OrdinalIgnoreCase));
+                //    if (preselectedTable != null)
+                //        predefinedTables[i] = preselectedTable;
+                //}
 
                 var ptd = _package.GetView<IPickTablesDialog>()
                                   .AddTables(predefinedTables)

--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineerHandler.cs
@@ -148,10 +148,17 @@ namespace EFCorePowerTools.Handlers
                     }
                 }
 
+                for (var i = 0; i < predefinedTables.Count; i++)
+                {
+                    var preselectedTable = preselectedTables.FirstOrDefault(c => c.Name.Equals(predefinedTables[i].Name, StringComparison.OrdinalIgnoreCase));
+                    if (preselectedTable != null)
+                        predefinedTables[i] = preselectedTable;
+                }
+
                 var ptd = _package.GetView<IPickTablesDialog>()
                                   .AddTables(predefinedTables)
                                   .PreselectTables(preselectedTables);
-                
+
                 var customNameOptions = CustomNameOptionsExtensions.TryRead(renamingPath);
 
                 var pickTablesResult = ptd.ShowAndAwaitUserResponse(true);
@@ -236,7 +243,7 @@ namespace EFCorePowerTools.Handlers
 
                     if (rightsAndVersion.Item1 == false)
                     {
-                        EnvDteHelper.ShowMessage("The SQL Server user does not have 'VIEW DEFINITION' rights, default constraints may not be available.");        
+                        EnvDteHelper.ShowMessage("The SQL Server user does not have 'VIEW DEFINITION' rights, default constraints may not be available.");
                     }
 
                     if (rightsAndVersion.Item2.Major < 11)
@@ -292,7 +299,7 @@ namespace EFCorePowerTools.Handlers
                         }
                         project.ProjectItems.AddFromFile(revEngResult.ContextFilePath);
                     }
-                    
+
                     _package.Dte2.ItemOperations.OpenFile(revEngResult.ContextFilePath);
 
                     if (modelingOptionsResult.Payload.SelectedToBeGenerated == 1)

--- a/src/GUI/RevEng.Core.50/RevEng.Core.50.csproj
+++ b/src/GUI/RevEng.Core.50/RevEng.Core.50.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\RevEng.Core\ReverseEngineerRunner.cs" Link="ReverseEngineerRunner.cs" />
     <Compile Include="..\RevEng.Core\SharedTypeExtensions.cs" Link="SharedTypeExtensions.cs" />
     <Compile Include="..\RevEng.Core\TableListBuilder.cs" Link="TableListBuilder.cs" />
+    <Compile Include="..\RevEng.Core\VisitorRelationScaffoldingModelFactory.cs" Link="VisitorRelationScaffoldingModelFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GUI/RevEng.Core.50/ServiceProviderBuilder.cs
+++ b/src/GUI/RevEng.Core.50/ServiceProviderBuilder.cs
@@ -3,6 +3,7 @@ using ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
@@ -26,7 +27,18 @@ namespace ReverseEngineer20.ReverseEngineer
                 .AddEntityFrameworkDesignTimeServices()
                 .AddSingleton<ICSharpEntityTypeGenerator, CommentCSharpEntityTypeGenerator>()
                 .AddSingleton<IOperationReporter, OperationReporter>()
-                .AddSingleton<IOperationReportHandler, OperationReportHandler>();
+                .AddSingleton<IOperationReportHandler, OperationReportHandler>()
+                .AddSingleton<IScaffoldingModelFactory>(provider =>
+                  new VisitorRelationScaffoldingModelFactory(
+                     provider.GetService<IOperationReporter>(),
+                     provider.GetService<ICandidateNamingService>(),
+                     provider.GetService<IPluralizer>(),
+                     provider.GetService<ICSharpUtilities>(),
+                     provider.GetService<IScaffoldingTypeMapper>(),
+                     provider.GetService<LoggingDefinitions>(),
+                     options.Tables,
+                     options.DatabaseType
+                ));
 
             if (options.CustomReplacers != null)
             {

--- a/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
+++ b/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
@@ -3,6 +3,7 @@ using ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
@@ -27,7 +28,18 @@ namespace ReverseEngineer20.ReverseEngineer
                 .AddEntityFrameworkDesignTimeServices()
                 .AddSingleton<ICSharpEntityTypeGenerator, CommentCSharpEntityTypeGenerator>()
                 .AddSingleton<IOperationReporter, OperationReporter>()
-                .AddSingleton<IOperationReportHandler, OperationReportHandler>();
+                .AddSingleton<IOperationReportHandler, OperationReportHandler>()
+                .AddSingleton<IScaffoldingModelFactory>(provider =>
+                  new VisitorRelationScaffoldingModelFactory(
+                     provider.GetService<IOperationReporter>(),
+                     provider.GetService<ICandidateNamingService>(),
+                     provider.GetService<IPluralizer>(),
+                     provider.GetService<ICSharpUtilities>(),
+                     provider.GetService<IScaffoldingTypeMapper>(),
+                     provider.GetService<LoggingDefinitions>(),
+                     options.Tables,
+                     options.DatabaseType
+                ));
 
             if (options.UseHandleBars)
             {

--- a/src/GUI/RevEng.Core/VisitorRelationScaffoldingModelFactory.cs
+++ b/src/GUI/RevEng.Core/VisitorRelationScaffoldingModelFactory.cs
@@ -13,43 +13,45 @@ using System.Linq;
 
 namespace ReverseEngineer20.ReverseEngineer
 {
-	public class VisitorRelationScaffoldingModelFactory : RelationalScaffoldingModelFactory
-	{
-		private readonly List<TableInformationModel> _tables;
-		private readonly DatabaseType _databaseType;
+    public class VisitorRelationScaffoldingModelFactory : RelationalScaffoldingModelFactory
+    {
+        private readonly List<TableInformationModel> _tables;
+        private readonly DatabaseType _databaseType;
 
-		public VisitorRelationScaffoldingModelFactory([NotNull] IOperationReporter reporter, [NotNull] ICandidateNamingService candidateNamingService, [NotNull] IPluralizer pluralizer, [NotNull] ICSharpUtilities cSharpUtilities, [NotNull] IScaffoldingTypeMapper scaffoldingTypeMapper, [NotNull] LoggingDefinitions loggingDefinitions, List<TableInformationModel> tables, DatabaseType databaseType) :
-			base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions)
-		{
-			_tables = tables;
-			_databaseType = databaseType;
-		}
+        public VisitorRelationScaffoldingModelFactory([NotNull] IOperationReporter reporter, [NotNull] ICandidateNamingService candidateNamingService, [NotNull] IPluralizer pluralizer, [NotNull] ICSharpUtilities cSharpUtilities, [NotNull] IScaffoldingTypeMapper scaffoldingTypeMapper, [NotNull] LoggingDefinitions loggingDefinitions, List<TableInformationModel> tables, DatabaseType databaseType) :
+            base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions)
+        {
+            _tables = tables;
+            _databaseType = databaseType;
+        }
 
-		protected override EntityTypeBuilder VisitTable(ModelBuilder modelBuilder, DatabaseTable table)
-		{
-			string fullTableName;
-			if (String.IsNullOrWhiteSpace(table.Schema))
-			{
-				fullTableName = table.Name;
-			}
-			else if (_databaseType == DatabaseType.SQLServer)
-			{
-				fullTableName = $"[{table.Schema}].[{table.Name}]";
-			}
-			else
-			{
-				fullTableName = $"{table.Schema}.{table.Name}";
-			}
-			var tableDefinition = _tables.FirstOrDefault(c => c.Name.Equals(fullTableName, StringComparison.OrdinalIgnoreCase));
-			if (tableDefinition != null && tableDefinition?.ExcludedColumns != null) {
-				foreach (var column in tableDefinition?.ExcludedColumns) {
-					var columnToRemove = table.Columns.FirstOrDefault(c => c.Name.Equals(column, StringComparison.OrdinalIgnoreCase));
-					if (columnToRemove != null)
-						table.Columns.Remove(columnToRemove);
-				}
-			}
+        protected override EntityTypeBuilder VisitTable(ModelBuilder modelBuilder, DatabaseTable table)
+        {
+            string fullTableName;
+            if (String.IsNullOrWhiteSpace(table.Schema))
+            {
+                fullTableName = table.Name;
+            }
+            else if (_databaseType == DatabaseType.SQLServer)
+            {
+                fullTableName = $"[{table.Schema}].[{table.Name}]";
+            }
+            else
+            {
+                fullTableName = $"{table.Schema}.{table.Name}";
+            }
+            var tableDefinition = _tables.FirstOrDefault(c => c.Name.Equals(fullTableName, StringComparison.OrdinalIgnoreCase));
+            if (tableDefinition?.ExcludedColumns != null)
+            {
+                foreach (var column in tableDefinition?.ExcludedColumns)
+                {
+                    var columnToRemove = table.Columns.FirstOrDefault(c => c.Name.Equals(column, StringComparison.OrdinalIgnoreCase));
+                    if (columnToRemove != null)
+                        table.Columns.Remove(columnToRemove);
+                }
+            }
 
-			return base.VisitTable(modelBuilder, table);
-		}
-	}
+            return base.VisitTable(modelBuilder, table);
+        }
+    }
 }

--- a/src/GUI/RevEng.Core/VisitorRelationScaffoldingModelFactory.cs
+++ b/src/GUI/RevEng.Core/VisitorRelationScaffoldingModelFactory.cs
@@ -1,0 +1,55 @@
+﻿using EFCorePowerTools.Shared.Models;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ReverseEngineer20.ReverseEngineer
+{
+	public class VisitorRelationScaffoldingModelFactory : RelationalScaffoldingModelFactory
+	{
+		private readonly List<TableInformationModel> _tables;
+		private readonly DatabaseType _databaseType;
+
+		public VisitorRelationScaffoldingModelFactory([NotNull] IOperationReporter reporter, [NotNull] ICandidateNamingService candidateNamingService, [NotNull] IPluralizer pluralizer, [NotNull] ICSharpUtilities cSharpUtilities, [NotNull] IScaffoldingTypeMapper scaffoldingTypeMapper, [NotNull] LoggingDefinitions loggingDefinitions, List<TableInformationModel> tables, DatabaseType databaseType) :
+			base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions)
+		{
+			_tables = tables;
+			_databaseType = databaseType;
+		}
+
+		protected override EntityTypeBuilder VisitTable(ModelBuilder modelBuilder, DatabaseTable table)
+		{
+			string fullTableName;
+			if (String.IsNullOrWhiteSpace(table.Schema))
+			{
+				fullTableName = table.Name;
+			}
+			else if (_databaseType == DatabaseType.SQLServer)
+			{
+				fullTableName = $"[{table.Schema}].[{table.Name}]";
+			}
+			else
+			{
+				fullTableName = $"{table.Schema}.{table.Name}";
+			}
+			var tableDefinition = _tables.FirstOrDefault(c => c.Name.Equals(fullTableName, StringComparison.OrdinalIgnoreCase));
+			if (tableDefinition != null && tableDefinition?.ExcludedColumns != null) {
+				foreach (var column in tableDefinition?.ExcludedColumns) {
+					var columnToRemove = table.Columns.FirstOrDefault(c => c.Name.Equals(column, StringComparison.OrdinalIgnoreCase));
+					if (columnToRemove != null)
+						table.Columns.Remove(columnToRemove);
+				}
+			}
+
+			return base.VisitTable(modelBuilder, table);
+		}
+	}
+}

--- a/src/GUI/RevEng.Shared/TableInformationModel.cs
+++ b/src/GUI/RevEng.Shared/TableInformationModel.cs
@@ -92,7 +92,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the object type.
+        /// Gets or sets the columns excluded from reverse engineering.
         /// </summary>
         [DataMember]
         public IEnumerable<string> ExcludedColumns

--- a/src/GUI/RevEng.Shared/TableInformationModel.cs
+++ b/src/GUI/RevEng.Shared/TableInformationModel.cs
@@ -20,7 +20,7 @@
         private bool _hasPrimaryKey;
         private bool _showKeylessWarning;
         private ObjectType _objectType;
-        private IEnumerable<string> _excludedColumns = new List<string>();
+        private IEnumerable<string> _excludedColumns;
 
         /// <summary>
         /// Gets or sets the table name.
@@ -94,7 +94,7 @@
         /// <summary>
         /// Gets or sets the columns excluded from reverse engineering.
         /// </summary>
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public IEnumerable<string> ExcludedColumns
         {
             get => _excludedColumns;
@@ -126,7 +126,7 @@
             HasPrimaryKey = hasPrimaryKey;
             ShowKeylessWarning = showKeylessWarning;
             ObjectType = objectType;
-            if (excludedColumns != null) ExcludedColumns = excludedColumns;
+            ExcludedColumns = excludedColumns;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/GUI/RevEng.Shared/TableInformationModel.cs
+++ b/src/GUI/RevEng.Shared/TableInformationModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace EFCorePowerTools.Shared.Models
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Runtime.CompilerServices;
@@ -19,6 +20,7 @@
         private bool _hasPrimaryKey;
         private bool _showKeylessWarning;
         private ObjectType _objectType;
+        private IEnumerable<string> _excludedColumns = new List<string>();
 
         /// <summary>
         /// Gets or sets the table name.
@@ -90,6 +92,21 @@
         }
 
         /// <summary>
+        /// Gets or sets the object type.
+        /// </summary>
+        [DataMember]
+        public IEnumerable<string> ExcludedColumns
+        {
+            get => _excludedColumns;
+            set
+            {
+                if (value == _excludedColumns) return;
+                _excludedColumns = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TableInformationModel"/> class for a specific table.
         /// </summary>
         /// <param name="name">The table name.</param>
@@ -99,7 +116,8 @@
         public TableInformationModel(string name,
                                      bool hasPrimaryKey,
                                      bool showKeylessWarning = false,
-                                     ObjectType objectType = ObjectType.Table)
+                                     ObjectType objectType = ObjectType.Table,
+                                     IEnumerable<string> excludedColumns = null)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException(@"Value cannot be empty or only white spaces.", nameof(name));
@@ -108,6 +126,7 @@
             HasPrimaryKey = hasPrimaryKey;
             ShowKeylessWarning = showKeylessWarning;
             ObjectType = objectType;
+            if (excludedColumns != null) ExcludedColumns = excludedColumns;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/GUI/efreveng/TestFiles/efreveng572.txt
+++ b/src/GUI/efreveng/TestFiles/efreveng572.txt
@@ -1,0 +1,44 @@
+{
+   "ConnectionString": "Data Source=(local);Initial Catalog=Northwind;Integrated Security=True",   
+   "ContextClassName": "NorthwindContext",
+   "CustomReplacers": null,
+   "Dacpac": null,
+   "DatabaseType": 3,
+   "DefaultDacpacSchema": null,
+   "DoNotCombineNamespace": false,
+   "IdReplace": false,
+   "IncludeConnectionString": false,
+   "OutputPath": "Models",
+   "OutputContextPath": null,
+   "ModelNamespace": "Models",
+   "ContextNamespace": "Context",
+   "ProjectPath": "C:\\Temp\\Test\\",
+   "ProjectRootNamespace": "Northwind.Dal.Sql",
+   "SelectedHandlebarsLanguage": 0,
+   "SelectedToBeGenerated": 0,
+   "Tables": [
+      {
+         "HasPrimaryKey": true,
+         "Name": "dbo.Categories",
+         "ExcludedColumns": [ "Picture" ]
+      },
+      {
+         "HasPrimaryKey": true,
+         "Name": "dbo.Shippers"
+      },
+      {
+         "HasPrimaryKey": true,
+         "Name": "dbo.Region"
+      },
+      {
+         "HasPrimaryKey": true,
+         "Name": "dbo.RegionShippers"
+      }
+   ],
+   "UseDatabaseNames": true,
+   "UseFluentApiOnly": true,
+   "UseHandleBars": false,
+   "UseDbContextSplitting": false,
+   "UseInflector": true,
+   "UseLegacyPluralizer": false
+}


### PR DESCRIPTION
The modifications are quite simple. I have added the ExcludedColumns in the TableInformationModel. 
The awkward part is in the ReverseEngineerHandler. I had to replace predefined tables with preselected ones when the names match. This is necessary because the UI serializes from predefined tables and that would overwrite any change made by the user to the efpt.config.json file. If you have a better idea I'm all ears :)