### PR TITLE
Add UI to select column of a table

### DIFF
--- a/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
@@ -113,7 +113,7 @@
                         <HierarchicalDataTemplate.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="1" Orientation="Horizontal">
-                                    <CheckBox Margin="1" IsChecked="{Binding IsSelected}"/>
+                                    <CheckBox Margin="1" IsChecked="{Binding IsSelected}" IsEnabled="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TreeViewItem}, AncestorLevel=2}, Path=DataContext.IsSelected}"/>
                                     <TextBlock Margin="1" Text="{Binding Name}"/>
                                 </StackPanel>
                             </DataTemplate>

--- a/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/PickTablesDialog.xaml
@@ -98,26 +98,29 @@
                          Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
 
-            <ListBox Margin="12,0"
-                     Height="302"
-                     ItemsSource="{Binding FilteredTables}">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Horizontal"
-                                    d:DataContext="{d:DesignInstance Type=viewModels:TableInformationViewModel, IsDesignTimeCreatable=false}">
-                            <CheckBox Style="{StaticResource TableSelectionCheckBoxStyle}"
-                                      IsChecked="{Binding IsSelected}" />
-                            <TextBlock Text="{Binding Name}" 
-                                       Style="{StaticResource TableNameTextBlockStyle}"/>
-                            <Image Style="{StaticResource KeylessImageStyle}"
-                                   Visibility="{Binding ShowKeylessWarning, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <Image Style="{StaticResource IsProcedureImageStyle}"
-                                   Visibility="{Binding IsProcedure, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            <TreeView Margin="12,0"
+                      Height="302"
+                      ItemsSource="{Binding FilteredTables}"
+                      VirtualizingStackPanel.IsVirtualizing="True"
+                      VirtualizingStackPanel.VirtualizationMode="Recycling">
+                <TreeView.ItemTemplate>
+                    <HierarchicalDataTemplate ItemsSource="{Binding Path=Columns}">
+                        <StackPanel Margin="1" Orientation="Horizontal">
+                            <CheckBox Margin="1" IsChecked="{Binding IsSelected}" />
+                            <TextBlock Margin="1" Text="{Binding Name}"/>
                         </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
 
+                        <HierarchicalDataTemplate.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="1" Orientation="Horizontal">
+                                    <CheckBox Margin="1" IsChecked="{Binding IsSelected}"/>
+                                    <TextBlock Margin="1" Text="{Binding Name}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </HierarchicalDataTemplate.ItemTemplate>
+                    </HierarchicalDataTemplate>
+                </TreeView.ItemTemplate>
+            </TreeView>
             <StackPanel Orientation="Horizontal">
                 <dw:DialogButton Content="OK"
                                  IsDefault="True"

--- a/src/GUI/EFCorePowerTools/ViewModels/PickTablesViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/PickTablesViewModel.cs
@@ -32,6 +32,7 @@
         public ICommand LoadedCommand { get; }
         public ICommand SaveSelectionCommand { get; }
         public ICommand LoadSelectionCommand { get; }
+        public ICommand TableSelectionCommand { get; }
         public ICommand OkCommand { get; }
         public ICommand CancelCommand { get; }
 
@@ -234,11 +235,11 @@
             {
                 var t = tables.SingleOrDefault(m => m.Name == table.Name);
                 table.IsSelected = t != null;
-                if (table.ObjectType == ObjectType.Table)
+                if (table.ObjectType == ObjectType.Table && table.IsSelected)
                 {
                     foreach (var column in table.Columns)
                     {
-                        column.IsSelected = t?.Columns?.Any(m => m != column.Name) ?? true;
+                        column.IsSelected = !t?.Columns?.Any(m => m == column.Name) ?? true;
                     }
                 }
             }

--- a/src/GUI/EFCorePowerTools/ViewModels/TableInformationViewModel.cs
+++ b/src/GUI/EFCorePowerTools/ViewModels/TableInformationViewModel.cs
@@ -62,6 +62,10 @@
             {
                 if (Equals(value, _isSelected)) return;
                 _isSelected = value;
+                foreach(var column in Columns)
+                {
+                    column.IsSelected = _isSelected;
+                }
                 RaisePropertyChanged();
             }
         }

--- a/src/GUI/UnitTests/ViewModels/PickTablesViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/PickTablesViewModelTests.cs
@@ -1624,6 +1624,52 @@ namespace UnitTests.ViewModels
             AreTableEqual(c[5], result[4], false);
         }
 
+        [Test]
+        public void GetResults_WithTables_Modified()
+        {
+            // Arrange
+            var osa = Mock.Of<IOperatingSystemAccess>();
+            var fsa = Mock.Of<IFileSystemAccess>();
+
+            ITableInformationViewModel CreateTableInformationViewModelMockObject()
+            {
+                var mock = new Mock<ITableInformationViewModel>();
+                mock.SetupAllProperties();
+                mock.SetupGet(g => g.Columns).Returns(new ObservableCollection<IColumnInformationViewModel>());
+                return mock.Object;
+            }
+
+            IColumnInformationViewModel CreateColumnInformationViewModelMockObject()
+            {
+                var mock = new Mock<IColumnInformationViewModel>();
+                mock.SetupAllProperties();
+                return mock.Object;
+            }
+
+            IPickTablesViewModel vm = new PickTablesViewModel(osa, fsa, CreateTableInformationViewModelMockObject, CreateColumnInformationViewModelMockObject);
+            var tt = GetTestViewModels();
+            var c = tt.Select(m => new TableModel(m.Name, m.HasPrimaryKey, m.ObjectType, m.Columns.Select(co => co.Name))).ToArray();
+            foreach (var table in tt)
+            {
+                vm.Tables.Add(table);
+            }
+
+            // Act
+            vm.Tables[1].IsSelected = false;
+            vm.Tables[2].Columns.First().IsSelected = false;
+
+            var result = vm.GetResult();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(4, result.Length);
+            AreTableEqual(c[2], result[0], false);
+            AreTableEqual(c[3], result[1], false);
+            Assert.IsFalse(result[1].Columns.Any(tc => tc == result[2].Columns.First()));
+            AreTableEqual(c[4], result[2], false);
+            AreTableEqual(c[5], result[3], false);
+        }
+
         private static ITableInformationViewModel[] GetTestViewModels()
         {
             var r = new ITableInformationViewModel[6];

--- a/src/GUI/UnitTests/ViewModels/TableInformationViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/TableInformationViewModelTests.cs
@@ -3,6 +3,9 @@
 namespace UnitTests.ViewModels
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.Shared.Models;
     using EFCorePowerTools.ViewModels;
     using RevEng.Shared;
@@ -176,6 +179,29 @@ namespace UnitTests.ViewModels
 
             // Assert
             Assert.IsTrue(propertyChangedInvoked);
+        }
+
+        [Test]
+        public void PropertyChanged_IsSelected_ColumnsSelection([Values(true, false)] bool isSelected)
+        {
+            // Arrange
+            var vm = new TableInformationViewModel
+            {
+                Name = "dbo.album",
+                ObjectType = ObjectType.Table,
+                HasPrimaryKey = true,
+                IsSelected = isSelected,
+            };
+            vm.Columns.Add(new ColumnInformationViewModel { Name = "column1" });
+            vm.Columns.Add(new ColumnInformationViewModel { Name = "column2" });
+            vm.Columns.Add(new ColumnInformationViewModel { Name = "column3" });
+
+
+            // Act
+            vm.IsSelected = !isSelected;
+
+            // Assert
+            Assert.IsTrue(vm.Columns.All(c => c.IsSelected == !isSelected));
         }
     }
 }


### PR DESCRIPTION
- Changed from ListBox to TreeView for tables and column selection
- Columns of unselected tables are also unselected. When user selects a table all columns are selected. User can unselect columns. 
- Enabled UI virtualization in TreeView and tested it with 700 tables and 6000 columns. Rendering time: less than a second on my laptop. This avoids columns lazy loading in the TreeView.
- Fixes #596 
