### PR TITLE
Search for renaming file in same folder as config file

### DIFF
--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -83,23 +83,23 @@ namespace EFCorePowerTools.Extensions
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            string projectPath;
+            string renamingPath;
 
             if (string.IsNullOrEmpty(optionsPath))
             {
-                projectPath = project.Properties.Item("FullPath")?.Value.ToString();
+                renamingPath = project.Properties.Item("FullPath")?.Value.ToString();
 
-                if (string.IsNullOrEmpty(projectPath))
+                if (string.IsNullOrEmpty(renamingPath))
                 {
                     return null;
                 }
             }
             else
             {
-                projectPath = Path.GetDirectoryName(optionsPath);
+                renamingPath = Path.GetDirectoryName(optionsPath);
             }
 
-            return Path.Combine(projectPath, "efpt.renaming.json");
+            return Path.Combine(renamingPath, "efpt.renaming.json");
         }
 
 

--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -79,15 +79,24 @@ namespace EFCorePowerTools.Extensions
             return result.OrderBy(s => s).ToList();
         }
 
-        public static string GetRenamingPath(this Project project)
+        public static string GetRenamingPath(this Project project, string optionsPath)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            var projectPath = project.Properties.Item("FullPath")?.Value.ToString();
+            string projectPath;
 
-            if (string.IsNullOrEmpty(projectPath))
+            if (string.IsNullOrEmpty(optionsPath))
             {
-                return null;
+                projectPath = project.Properties.Item("FullPath")?.Value.ToString();
+
+                if (string.IsNullOrEmpty(projectPath))
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                projectPath = Path.GetDirectoryName(optionsPath);
             }
 
             return Path.Combine(projectPath, "efpt.renaming.json");

--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using VSLangProj;
 
 namespace EFCorePowerTools.Extensions
@@ -99,7 +100,17 @@ namespace EFCorePowerTools.Extensions
                 renamingPath = Path.GetDirectoryName(optionsPath);
             }
 
-            return Path.Combine(renamingPath, "efpt.renaming.json");
+            Regex customNamingRegex = new Regex(@"efpt.(?<xx>.{1,})config.json", RegexOptions.IgnoreCase);
+            Match customFileNameCheck = customNamingRegex.Match(Path.GetFileName(optionsPath));
+
+            string customConfigFileName = string.Empty;
+
+            if (customFileNameCheck.Success)
+            {
+                customConfigFileName = customFileNameCheck.Groups[1].Value;
+            }
+
+            return Path.Combine(renamingPath, $"efpt.{customConfigFileName}renaming.json");
         }
 
 

--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -107,7 +107,10 @@ namespace EFCorePowerTools.Extensions
 
             if (customFileNameCheck.Success)
             {
-                customConfigFileName = customFileNameCheck.Groups[1].Value;
+                if (customFileNameCheck.Groups.Count > 1)
+                {
+                    customConfigFileName = customFileNameCheck.Groups[1].Value;
+                }
             }
 
             return Path.Combine(renamingPath, $"efpt.{customConfigFileName}renaming.json");

--- a/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
+++ b/src/GUI/EFCorePowerTools/Extensions/ProjectExtensions.cs
@@ -100,22 +100,8 @@ namespace EFCorePowerTools.Extensions
                 renamingPath = Path.GetDirectoryName(optionsPath);
             }
 
-            Regex customNamingRegex = new Regex(@"efpt.(?<xx>.{1,})config.json", RegexOptions.IgnoreCase);
-            Match customFileNameCheck = customNamingRegex.Match(Path.GetFileName(optionsPath));
-
-            string customConfigFileName = string.Empty;
-
-            if (customFileNameCheck.Success)
-            {
-                if (customFileNameCheck.Groups.Count > 1)
-                {
-                    customConfigFileName = customFileNameCheck.Groups[1].Value;
-                }
-            }
-
-            return Path.Combine(renamingPath, $"efpt.{customConfigFileName}renaming.json");
+            return Path.Combine(renamingPath, "efpt.renaming.json");
         }
-
 
         public static async System.Threading.Tasks.Task<string> GetCspPropertyAsync(this Project project, string propertyName)
         {

--- a/src/GUI/EFCorePowerTools/Handlers/ReverseEngineer/ReverseEngineerHandler.cs
+++ b/src/GUI/EFCorePowerTools/Handlers/ReverseEngineer/ReverseEngineerHandler.cs
@@ -94,7 +94,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                     return;
                 }
 
-                var renamingPath = project.GetRenamingPath();
+                var renamingPath = project.GetRenamingPath(optionsPath);
                 var namingOptionsAndPath = CustomNameOptionsExtensions.TryRead(renamingPath, optionsPath);
 
                 Tuple<bool, string> containsEfCoreReference = null;


### PR DESCRIPTION
Context : 
Having several efpt.config.json on a project, forced to have only one renaming file. 
Also, can't share renaming setup between efpt.config.json cause renaming file is getting purged with only matching config.

-- efpt.renaming.json
-- Base1
---- efpt.config.json
-- Base 2
---- efpt.config.json

Solution :
Look for renaming file on same folder than the config file. 

-- Base1
---- efpt.config.json
---- efpt.renaming.json
-- Base 2
---- efpt.config.json
---- efpt.renaming.json
