### PR TITLE
Introduced schema folder separation and cleanup method improvements.

### DIFF
--- a/src/GUI/EFCorePowerTools.Shared/Models/ModelingOptionsModel.cs
+++ b/src/GUI/EFCorePowerTools.Shared/Models/ModelingOptionsModel.cs
@@ -19,6 +19,7 @@
         private string _ns;
         private string _outputPath;
         private string _outputContextPath;
+        private bool _useSchemaFolders;
         private string _modelNamespace;
         private string _contextNamespace;
         private string _modelName;
@@ -76,6 +77,17 @@
             {
                 if (value == _outputContextPath) return;
                 _outputContextPath = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool UseSchemaFolders
+        {
+            get => _useSchemaFolders;
+            set
+            {
+                if (value == _useSchemaFolders) return;
+                _useSchemaFolders = value;
                 OnPropertyChanged();
             }
         }

--- a/src/GUI/EFCorePowerTools/Dialogs/AdvancedModelingOptionsDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Dialogs/AdvancedModelingOptionsDialog.xaml
@@ -97,6 +97,12 @@
                       IsChecked="{Binding Model.ProceduresReturnList}"
                       Style="{StaticResource MarginCheckBlockStyle}"
                       TabIndex="9" />
+
+            <CheckBox Content="{x:Static locale:ReverseEngineerLocale.UseSchemaFolders}"
+                      IsChecked="{Binding Model.UseSchemaFolders}"
+                      Style="{StaticResource MarginCheckBlockStyle}"
+                      TabIndex="10" />
+
         </StackPanel>
 
         <StackPanel Grid.Row="20"

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.Designer.cs
@@ -765,6 +765,15 @@ namespace EFCorePowerTools.Locales {
         /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
+        public static string UseSchemaFolders {
+            get {
+                return ResourceManager.GetString("UseSchemaFolders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
         public static string UseTextSearch {
             get {
                 return ResourceManager.GetString("UseTextSearch", resourceCulture);

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.en.resx
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.en.resx
@@ -351,6 +351,9 @@
   <data name="UseRegularExpression" xml:space="preserve">
     <value>Use regular expression</value>
   </data>
+  <data name="UseSchemaFolders" xml:space="preserve">
+    <value>Use schema folder separation (experimental)</value>
+  </data>
   <data name="UseTextSearch" xml:space="preserve">
     <value>Use text search</value>
   </data>

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.fr.resx
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.fr.resx
@@ -351,6 +351,9 @@
   <data name="UseRegularExpression" xml:space="preserve">
     <value>Utiliser une expression régulière</value>
   </data>
+  <data name="UseSchemaFolders" xml:space="preserve">
+    <value>Utiliser la séparation des dossiers de schéma (expérimental)</value>
+  </data>
   <data name="UseTextSearch" xml:space="preserve">
     <value>Utiliser la recherche textuelle</value>
   </data>

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.it.resx
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.it.resx
@@ -351,6 +351,9 @@
   <data name="UseRegularExpression" xml:space="preserve">
     <value>Usa regular expression</value>
   </data>
+  <data name="UseSchemaFolders" xml:space="preserve">
+    <value>Usa la separazione delle cartelle dello schema (sperimentale)</value>
+  </data>
   <data name="UseTextSearch" xml:space="preserve">
     <value>Usa ricerca testuale</value>
   </data>

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.resx
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.resx
@@ -351,6 +351,9 @@
   <data name="UseRegularExpression" xml:space="preserve">
     <value />
   </data>
+  <data name="UseSchemaFolders" xml:space="preserve">
+    <value />
+  </data>
   <data name="UseTextSearch" xml:space="preserve">
     <value />
   </data>

--- a/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.tr.resx
+++ b/src/GUI/EFCorePowerTools/Locales/ReverseEngineerLocale.tr.resx
@@ -351,6 +351,9 @@
   <data name="UseRegularExpression" xml:space="preserve">
     <value>Düzenli ifade kullan</value>
   </data>
+  <data name="UseSchemaFolders" xml:space="preserve">
+    <value>Şema klasörü ayırma kullanın (deneysel)</value>
+  </data>
   <data name="UseTextSearch" xml:space="preserve">
     <value>Metin arama kullan</value>
   </data>

--- a/src/GUI/RevEng.Core.50/RevEng.Core.50.csproj
+++ b/src/GUI/RevEng.Core.50/RevEng.Core.50.csproj
@@ -33,7 +33,8 @@
 		<Compile Include="..\RevEng.Core\ServiceProviderBuilder.cs" Link="ServiceProviderBuilder.cs" />
 		<Compile Include="..\RevEng.Core\SharedTypeExtensions.cs" Link="SharedTypeExtensions.cs" />
 		<Compile Include="..\RevEng.Core\SqlServerHelper.cs" Link="SqlServerHelper.cs" />
-		<Compile Include="..\RevEng.Core\TableListBuilder.cs" Link="TableListBuilder.cs" />
+    <Compile Include="..\RevEng.Core\TableListBuilder.cs" Link="TableListBuilder.cs" />
+    <Compile Include="..\RevEng.Core\Tables\CSharpModelGeneratorExtend.cs" Link="Tables\CSharpModelGeneratorExtend.cs" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/GUI/RevEng.Core.60/RevEng.Core.60.csproj
+++ b/src/GUI/RevEng.Core.60/RevEng.Core.60.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net5.0</TargetFramework>
@@ -31,6 +31,7 @@
     <Compile Include="..\RevEng.Core\SharedTypeExtensions.cs" Link="SharedTypeExtensions.cs" />
     <Compile Include="..\RevEng.Core\SqlServerHelper.cs" Link="SqlServerHelper.cs" />
     <Compile Include="..\RevEng.Core\TableListBuilder.cs" Link="TableListBuilder.cs" />
+    <Compile Include="..\RevEng.Core\Tables\CSharpModelGeneratorExtend.cs" Link="Tables\CSharpModelGeneratorExtend.cs" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/GUI/RevEng.Core.Abstractions/ModuleScaffolderOptions.cs
+++ b/src/GUI/RevEng.Core.Abstractions/ModuleScaffolderOptions.cs
@@ -7,6 +7,7 @@
         public virtual string ContextNamespace { get; set; }
         public virtual string ModelNamespace { get; set; }
         public virtual bool NullableReferences { get; set; }
+        public virtual bool UseSchemaFolders { get; set; }
         public virtual bool ProceduresReturnList { get; set; }
     }
 }

--- a/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/GUI/RevEng.Core/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -70,7 +70,9 @@ namespace RevEng.Core.Procedures
                 result.AdditionalFiles.Add(new ScaffoldedFile
                 {
                     Code = classContent,
-                    Path = $"{name}.cs",
+                    Path = procedureScaffolderOptions.UseSchemaFolders
+                            ? Path.Combine(procedure.Schema, $"{name}.cs")
+                            : $"{name}.cs"
                 });
             }
 
@@ -103,6 +105,7 @@ namespace RevEng.Core.Procedures
             foreach (var entityTypeFile in scaffoldedModel.AdditionalFiles)
             {
                 var additionalFilePath = Path.Combine(outputDir, entityTypeFile.Path);
+                Directory.CreateDirectory(Path.GetDirectoryName(additionalFilePath));
                 File.WriteAllText(additionalFilePath, entityTypeFile.Code, Encoding.UTF8);
                 additionalFiles.Add(additionalFilePath);
             }

--- a/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
+++ b/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
@@ -256,7 +256,14 @@ namespace RevEng.Core
             if (filePaths.AdditionalFiles.Count == 0)
                 return;
 
-            foreach (var modelFile in Directory.GetFiles(Path.GetDirectoryName(filePaths.AdditionalFiles.First()), "*.cs"))
+            string[] modelFiles;
+            var allChildDirectories = filePaths.AdditionalFiles.Select(x => Path.GetDirectoryName(x)).Distinct().ToArray();
+            var parentDirectory = allChildDirectories.Length > 1
+                                   ? Directory.GetParent(allChildDirectories.First()).FullName
+                                   : allChildDirectories.First();
+            modelFiles = Directory.GetFiles(parentDirectory, "*.cs", SearchOption.AllDirectories);
+
+            foreach (var modelFile in modelFiles)
             {
                 if (allGeneratedFiles.Contains(modelFile, StringComparer.OrdinalIgnoreCase))
                 {
@@ -264,6 +271,14 @@ namespace RevEng.Core
                 }
 
                 TryRemoveFile(modelFile);
+            }
+
+            foreach (var directoryPath in Directory.GetDirectories(parentDirectory))
+            {
+                if(!Directory.EnumerateFileSystemEntries(directoryPath).Any())
+                {
+                    Directory.Delete(directoryPath);
+                }
             }
         }
 

--- a/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
+++ b/src/GUI/RevEng.Core/ReverseEngineerRunner.cs
@@ -118,7 +118,7 @@ namespace RevEng.Core
 
             var cleanUpPaths = CreateCleanupPaths(procedurePaths, functionPaths, filePaths);
 
-            CleanUp(cleanUpPaths, entityTypeConfigurationPaths);
+            CleanUp(cleanUpPaths, entityTypeConfigurationPaths, outputDir);
 
             var allfiles = filePaths.AdditionalFiles.ToList();
             if (procedurePaths != null)
@@ -232,7 +232,7 @@ namespace RevEng.Core
                 ;
         }
 
-        private static void CleanUp(SavedModelFiles filePaths, List<string> entityTypeConfigurationPaths)
+        private static void CleanUp(SavedModelFiles filePaths, List<string> entityTypeConfigurationPaths, string outputDir)
         {
             var allGeneratedFiles = filePaths.AdditionalFiles.Select(s => Path.GetFullPath(s)).Concat(entityTypeConfigurationPaths).ToHashSet();
 
@@ -256,14 +256,7 @@ namespace RevEng.Core
             if (filePaths.AdditionalFiles.Count == 0)
                 return;
 
-            string[] modelFiles;
-            var allChildDirectories = filePaths.AdditionalFiles.Select(x => Path.GetDirectoryName(x)).Distinct().ToArray();
-            var parentDirectory = allChildDirectories.Length > 1
-                                   ? Directory.GetParent(allChildDirectories.First()).FullName
-                                   : allChildDirectories.First();
-            modelFiles = Directory.GetFiles(parentDirectory, "*.cs", SearchOption.AllDirectories);
-
-            foreach (var modelFile in modelFiles)
+            foreach (var modelFile in Directory.GetFiles(outputDir, "*.cs", SearchOption.AllDirectories))
             {
                 if (allGeneratedFiles.Contains(modelFile, StringComparer.OrdinalIgnoreCase))
                 {
@@ -273,7 +266,7 @@ namespace RevEng.Core
                 TryRemoveFile(modelFile);
             }
 
-            foreach (var directoryPath in Directory.GetDirectories(parentDirectory))
+            foreach (var directoryPath in Directory.GetDirectories(outputDir))
             {
                 if(!Directory.EnumerateFileSystemEntries(directoryPath).Any())
                 {

--- a/src/GUI/RevEng.Core/ReverseEngineerScaffolder.cs
+++ b/src/GUI/RevEng.Core/ReverseEngineerScaffolder.cs
@@ -150,6 +150,7 @@ namespace RevEng.Core
                     ContextNamespace = contextNamespace,
                     ModelNamespace = modelNamespace,
                     NullableReferences = options.UseNullableReferences,
+                    UseSchemaFolders = options.UseSchemaFolders,
                     ProceduresReturnList = options.ProceduresReturnList,
                 };
 
@@ -247,6 +248,7 @@ namespace RevEng.Core
             foreach (var entityTypeFile in scaffoldedModel.AdditionalFiles)
             {
                 var additionalFilePath = Path.Combine(outputDir, entityTypeFile.Path);
+                Directory.CreateDirectory(Path.GetDirectoryName(additionalFilePath));
                 File.WriteAllText(additionalFilePath, entityTypeFile.Code, Encoding.UTF8);
                 additionalFiles.Add(additionalFilePath);
             }

--- a/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
+++ b/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
@@ -17,7 +17,6 @@ using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal;
 using RevEng.Core.Procedures;
-using RevEng.Core.Tables;
 using RevEng.Shared;
 #if CORE50
 using SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Design;
@@ -40,7 +39,7 @@ namespace RevEng.Core
                         provider.GetService<ModelCodeGeneratorDependencies>(),
                         provider.GetService<ICSharpDbContextGenerator>(),
                         provider.GetService<ICSharpEntityTypeGenerator>(),
-                        options))
+                        options.UseSchemaFolders))
 #if CORE50
                 .AddSingleton<ICSharpEntityTypeGenerator>(provider =>
                  new CommentCSharpEntityTypeGenerator(                    

--- a/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
+++ b/src/GUI/RevEng.Core/ServiceProviderBuilder.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal;
 using RevEng.Core.Procedures;
+using RevEng.Core.Tables;
 using RevEng.Shared;
 #if CORE50
 using SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Design;
@@ -34,6 +35,12 @@ namespace RevEng.Core
 
             serviceCollection
                 .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<IModelCodeGenerator>(provider =>
+                    new CSharpModelGeneratorExtend(
+                        provider.GetService<ModelCodeGeneratorDependencies>(),
+                        provider.GetService<ICSharpDbContextGenerator>(),
+                        provider.GetService<ICSharpEntityTypeGenerator>(),
+                        options))
 #if CORE50
                 .AddSingleton<ICSharpEntityTypeGenerator>(provider =>
                  new CommentCSharpEntityTypeGenerator(                    

--- a/src/GUI/RevEng.Core/Tables/CSharpModelGeneratorExtend.cs
+++ b/src/GUI/RevEng.Core/Tables/CSharpModelGeneratorExtend.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using RevEng.Shared;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace RevEng.Core.Tables
+{
+    /// <summary>
+    ///     This is an extension of internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. The base CSharpModelGenerator may be changed or removed without 
+    ///     notice in any release. Updating Entity Framework Core version in project may result application failures.
+    ///     
+    ///     Base class implementation: https://github.com/dotnet/efcore/blob/main/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+    /// </summary>
+    public class CSharpModelGeneratorExtend : CSharpModelGenerator
+    {
+        /// <summary>
+        ///     This is an extension of internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. The base CSharpModelGenerator may be changed or removed without 
+        ///     notice in any release. Updating Entity Framework Core version in project may result application failures.
+        /// </summary>
+        private ReverseEngineerCommandOptions ReverseEngineerCommandOptions { get; set; }
+
+        /// <summary>
+        ///     This is an extension of internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. The base CSharpModelGenerator may be changed or removed without 
+        ///     notice in any release. Updating Entity Framework Core version in project may result application failures.
+        /// </summary>
+        public CSharpModelGeneratorExtend(
+            ModelCodeGeneratorDependencies dependencies,
+            ICSharpDbContextGenerator cSharpDbContextGenerator,
+            ICSharpEntityTypeGenerator cSharpEntityTypeGenerator,
+            ReverseEngineerCommandOptions reverseEngineerCommandOptions)
+            : base(dependencies, cSharpDbContextGenerator, cSharpEntityTypeGenerator)
+        {
+            ReverseEngineerCommandOptions = reverseEngineerCommandOptions;
+        }
+
+        private const string FileExtension = ".cs";
+
+        /// <summary>
+        ///     This is an extension of internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. The base CSharpModelGenerator may be changed or removed without 
+        ///     notice in any release. Updating Entity Framework Core version in project may result application failures.
+        /// </summary>
+        public override ScaffoldedModel GenerateModel(
+            [NotNull] IModel model,
+            [NotNull] ModelCodeGenerationOptions options)
+        {
+            if (options.ContextName == null)
+            {
+                throw new ArgumentException(
+                    CoreStrings.ArgumentPropertyNull(nameof(options.ContextName), nameof(options)), nameof(options));
+            }
+
+            if (options.ConnectionString == null)
+            {
+                throw new ArgumentException(
+                    CoreStrings.ArgumentPropertyNull(nameof(options.ConnectionString), nameof(options)), nameof(options));
+            }
+
+            // TODO: Honor options.Nullable (issue #15520)
+            var generatedCode = CSharpDbContextGenerator.WriteCode(
+                model,
+                options.ContextName,
+                options.ConnectionString,
+                options.ContextNamespace,
+                options.ModelNamespace,
+                options.UseDataAnnotations,
+                options.SuppressConnectionStringWarning
+#if CORE50 || CORE60
+                ,options.SuppressOnConfiguring
+#endif
+                );
+            
+            // output DbContext .cs file
+            var dbContextFileName = options.ContextName + FileExtension;
+            var resultingFiles = new ScaffoldedModel
+            {
+                ContextFile = new ScaffoldedFile
+                {
+                    Path = options.ContextDir != null
+                        ? Path.Combine(options.ContextDir, dbContextFileName)
+                        : dbContextFileName,
+                    Code = generatedCode
+                }
+            };
+
+            foreach (var entityType in model.GetEntityTypes())
+            {
+                // TODO: Honor options.Nullable (issue #15520)
+                generatedCode = CSharpEntityTypeGenerator.WriteCode(entityType, options.ModelNamespace, options.UseDataAnnotations);
+
+                // output EntityType poco .cs file
+                var entityTypeFileName = entityType.Name + FileExtension;
+                resultingFiles.AdditionalFiles.Add(
+                    new ScaffoldedFile 
+                    {
+                        Path = ReverseEngineerCommandOptions.UseSchemaFolders
+                            ? Path.Combine(entityType.FindAnnotation("Relational:Schema")?.Value.ToString() ??
+                                           entityType.FindAnnotation("Relational:ViewSchema")?.Value.ToString() ??
+                                           "dbo", entityTypeFileName)
+                            : entityTypeFileName,
+                        Code = generatedCode 
+                    });
+            }
+
+            return resultingFiles;
+        }
+    }
+}

--- a/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
+++ b/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
@@ -9,6 +9,7 @@ namespace RevEng.Shared
         public string ProjectPath { get; set; }
         public string OutputPath { get; set; }
         public string OutputContextPath { get; set; }
+        public bool UseSchemaFolders { get; set; }
         public string ModelNamespace { get; set; }
         public string ContextNamespace { get; set; }
         public string ProjectRootNamespace { get; set; }

--- a/src/GUI/Shared/Handlers/ReverseEngineer/EfRevEngLauncher.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/EfRevEngLauncher.cs
@@ -34,6 +34,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 ContextNamespace = options.ContextNamespace,
                 ModelNamespace = options.ModelNamespace,
                 OutputContextPath = options.OutputContextPath,
+                UseSchemaFolders = options.UseSchemaFolders,
                 ProjectPath = options.ProjectPath,
                 ProjectRootNamespace = options.ProjectRootNamespace,
                 SelectedHandlebarsLanguage = options.SelectedHandlebarsLanguage,

--- a/src/GUI/Shared/Handlers/ReverseEngineer/ReverseEngineerHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/ReverseEngineerHandler.cs
@@ -377,6 +377,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 IncludeConnectionString = options.IncludeConnectionString,
                 OutputPath = options.OutputPath,
                 OutputContextPath = options.OutputContextPath,
+                UseSchemaFolders = options.UseSchemaFolders,
                 ModelNamespace = options.ModelNamespace,
                 ContextNamespace = options.ContextNamespace,
                 SelectedToBeGenerated = options.SelectedToBeGenerated,
@@ -407,6 +408,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
             options.OutputPath = modelingOptionsResult.Payload.OutputPath;
             options.OutputContextPath = modelingOptionsResult.Payload.OutputContextPath;
             options.ContextNamespace = modelingOptionsResult.Payload.ContextNamespace;
+            options.UseSchemaFolders = modelingOptionsResult.Payload.UseSchemaFolders;
             options.ModelNamespace = modelingOptionsResult.Payload.ModelNamespace;
             options.ProjectRootNamespace = modelingOptionsResult.Payload.Namespace;
             options.UseDatabaseNames = modelingOptionsResult.Payload.UseDatabaseNames;

--- a/src/GUI/Shared/Handlers/ReverseEngineer/ReverseEngineerOptions.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/ReverseEngineerOptions.cs
@@ -16,6 +16,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
         public string ProjectPath { get; set; }
         public string OutputPath { get; set; }
         public string OutputContextPath { get; set; }
+        public bool UseSchemaFolders { get; set; }
         public string ProjectRootNamespace { get; set; }
         public string ModelNamespace { get; set; }
         public string ContextNamespace { get; set; }

--- a/src/GUI/Shared/ViewModels/AdvancedModelingOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/AdvancedModelingOptionsViewModel.cs
@@ -47,6 +47,7 @@
             Model.UseNoObjectFilter = presets.UseNoObjectFilter;
             Model.UseNullableReferences = presets.UseNullableReferences;
             Model.ProceduresReturnList = presets.ProceduresReturnList;
+            Model.UseSchemaFolders = presets.UseSchemaFolders;
         }
     }
 }

--- a/src/GUI/Shared/ViewModels/ModelingOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ModelingOptionsViewModel.cs
@@ -150,6 +150,7 @@ namespace EFCorePowerTools.ViewModels
             Model.UseNullableReferences = advancedModelingOptionsResult.Payload.UseNullableReferences;
             Model.UseNoObjectFilter = advancedModelingOptionsResult.Payload.UseNoObjectFilter;
             Model.ProceduresReturnList = advancedModelingOptionsResult.Payload.ProceduresReturnList;
+            Model.UseSchemaFolders = advancedModelingOptionsResult.Payload.UseSchemaFolders;
         }
 
         void IModelingOptionsViewModel.ApplyPresets(ModelingOptionsModel presets)
@@ -164,6 +165,7 @@ namespace EFCorePowerTools.ViewModels
             Model.Namespace = presets.Namespace;
             Model.OutputPath = presets.OutputPath;
             Model.OutputContextPath = presets.OutputContextPath;
+            Model.UseSchemaFolders = presets.UseSchemaFolders;
             Model.ModelNamespace = presets.ModelNamespace;
             Model.ContextNamespace = presets.ContextNamespace;
             Model.ModelName = presets.ModelName;


### PR DESCRIPTION
I have introduced schema folder separation per issue: [https://github.com/ErikEJ/EFCorePowerTools/issues/158](https://github.com/ErikEJ/EFCorePowerTools/issues/158)

These changes include AdvancedModelingOptionsDialog and **Use schema folder separation** is added as the last option of Advance settings. You can see this in the following image. This setting is saved as UseSchemaFolders property in JSON and it is used through all changes in code.

![image](https://user-images.githubusercontent.com/9116968/118189706-688f6000-b442-11eb-896a-0c7f852909c6.png)

There are a little bit complex changes inside **CleanUp** method because of supporting switching between schema and non-schema option and removing all directories and their files.

