### PR TITLE
Use uppercase routineType to support databases with BIN collations

### DIFF
--- a/src/GUI/RevEng.Core/Routines/SqlServerRoutineModelFactory.cs
+++ b/src/GUI/RevEng.Core/Routines/SqlServerRoutineModelFactory.cs
@@ -25,8 +25,8 @@ namespace RevEng.Core.Procedures
         {
             var routineType = this switch
             {
-                SqlServerStoredProcedureModelFactory _ => "procedure",
-                SqlServerFunctionModelFactory _ => "function",
+                SqlServerStoredProcedureModelFactory _ => "PROCEDURE",
+                SqlServerFunctionModelFactory _ => "FUNCTION",
                 _ => throw new InvalidOperationException($"Unknown type '{GetType().Name}'"),
             };
 


### PR DESCRIPTION
We upgraded from EF_Core_Power_Tools_v2.5.**454** to EF_Core_Power_Tools_v2.5.**692** and stopped seeing the Stored Procedures listed on the "Choose Database Objects" form. After downgrading to 2.5.454 again we can reverse engineer procedures again.

The database collation is: SQL_Latin1_General_CP850_BIN

In SQL Profiler we can see lower case procedure being used for ROUTINE_TYPE and this query returns no results:
```
SELECT
    ROUTINE_SCHEMA,
    ROUTINE_NAME,
    ROUTINE_TYPE,
    CAST(CASE WHEN (ROUTINE_TYPE = 'FUNCTION' AND DATA_TYPE != 'TABLE') THEN 1 ELSE 0 END AS bit) AS IS_SCALAR
FROM INFORMATION_SCHEMA.ROUTINES
WHERE NULLIF(ROUTINE_NAME, '') IS NOT NULL
AND ROUTINE_TYPE = 'procedure'
ORDER BY ROUTINE_NAME;
```

The corrected SQL returns the expected data:
```
SELECT
    ROUTINE_SCHEMA,
    ROUTINE_NAME,
    ROUTINE_TYPE,
    CAST(CASE WHEN (ROUTINE_TYPE = 'FUNCTION' AND DATA_TYPE != 'TABLE') THEN 1 ELSE 0 END AS bit) AS IS_SCALAR
FROM INFORMATION_SCHEMA.ROUTINES
WHERE NULLIF(ROUTINE_NAME, '') IS NOT NULL
AND ROUTINE_TYPE = 'PROCEDURE'
ORDER BY ROUTINE_NAME;
```


