### PR TITLE
IsNullOrEmpty => IsNullOrWhiteSpace in TableListBuilder.GetTableModels

### DIFF
--- a/src/GUI/RevEng.Core/TableListBuilder.cs
+++ b/src/GUI/RevEng.Core/TableListBuilder.cs
@@ -49,7 +49,7 @@ namespace RevEng.Core
                 var foreignKeyColumnNames = databaseTable.ForeignKeys?.SelectMany(c => c.Columns).Select(c => c.Name).ToHashSet();
                 var indexColumns = databaseTable.Indexes?.SelectMany(c => c.Columns);
 
-                foreach (var colum in databaseTable.Columns.Where(c => !string.IsNullOrEmpty(c.Name)))
+                foreach (var colum in databaseTable.Columns.Where(c => !string.IsNullOrWhiteSpace(c.Name)))
                 {
                     columns.Add(new ColumnModel(colum.Name, primaryKeyColumnNames?.Contains(colum.Name) ?? false, foreignKeyColumnNames?.Contains(colum.Name) ?? false));
                 }


### PR DESCRIPTION
Cause the evaluation of the name is based on whitestring and not on empty. Did not realize that yesterday - sorry!
https://github.com/ErikEJ/EFCorePowerTools/blob/79f32e1764be53fcf0454b28d5c1dc017e980211/src/GUI/RevEng.Shared/ColumnModel.cs#L42