### PR TITLE
Nuget updates and removed deprecated

### DIFF
--- a/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
+++ b/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
@@ -33,7 +33,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EFCorePowerTools</RootNamespace>
     <AssemblyName>EFCorePowerTools</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -452,8 +452,8 @@
   <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" Version="2.6.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Community.VisualStudio.Toolkit.17">
-      <Version>17.0.394</Version>
+    <PackageReference Include="Community.VisualStudio.Toolkit.16">
+      <Version>16.0.394</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm">
       <Version>7.1.2</Version>
@@ -465,7 +465,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Data.Framework">
-      <Version>17.0.32112.339</Version>
+      <Version>16.10.31320.204</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.39</Version>

--- a/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
+++ b/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
@@ -33,7 +33,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EFCorePowerTools</RootNamespace>
     <AssemblyName>EFCorePowerTools</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -450,10 +450,13 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AdysTech.CredentialManager" Version="2.3.0" />
+    <PackageReference Include="AdysTech.CredentialManager" Version="2.6.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Community.VisualStudio.Toolkit.16">
-      <Version>16.0.355</Version>
+    <PackageReference Include="Community.VisualStudio.Toolkit.17">
+      <Version>17.0.394</Version>
+    </PackageReference>
+    <PackageReference Include="CommunityToolkit.Mvvm">
+      <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
@@ -462,18 +465,10 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Data.Framework">
-      <Version>16.9.31025.104</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.5232</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+      <Version>17.0.32112.339</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.31</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmLightLibs">
-      <Version>5.4.1.1</Version>
+      <Version>1.1.39</Version>
     </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
       <Version>5.11.0</Version>

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
@@ -15,7 +15,7 @@ using EFCorePowerTools.Shared.BLL;
 using EFCorePowerTools.Shared.DAL;
 using EFCorePowerTools.Shared.Models;
 using EFCorePowerTools.ViewModels;
-using GalaSoft.MvvmLight.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -408,7 +408,7 @@ namespace EFCorePowerTools
                     .AddTransient<ICompareResultViewModel, CompareResultViewModel>();
 
             // Register BLL
-            var messenger = new Messenger();
+            var messenger = new WeakReferenceMessenger();
             messenger.Register<ShowMessageBoxMessage>(this, HandleShowMessageBoxMessage);
 
             services.AddSingleton<IExtensionVersionService, ExtensionVersionService>()
@@ -424,7 +424,7 @@ namespace EFCorePowerTools
             return services.BuildServiceProvider();
         }
 
-        private void HandleShowMessageBoxMessage(ShowMessageBoxMessage msg)
+        private void HandleShowMessageBoxMessage(object sender, ShowMessageBoxMessage msg)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 

--- a/src/GUI/EFCorePowerTools/Locales/AboutLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/AboutLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class AboutLocale {

--- a/src/GUI/EFCorePowerTools/Locales/CompareLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/CompareLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class CompareLocale {

--- a/src/GUI/EFCorePowerTools/Locales/DgmlLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/DgmlLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class DgmlLocale {

--- a/src/GUI/EFCorePowerTools/Locales/MigrationsLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/MigrationsLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class MigrationsLocale {

--- a/src/GUI/EFCorePowerTools/Locales/ModelAnalyzerLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/ModelAnalyzerLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ModelAnalyzerLocale {

--- a/src/GUI/EFCorePowerTools/Locales/SharedLocale.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Locales/SharedLocale.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools.Locales {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class SharedLocale {

--- a/src/GUI/EFCorePowerTools/Resources.Designer.cs
+++ b/src/GUI/EFCorePowerTools/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace EFCorePowerTools {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/GUI/EFCorePowerTools/app.config
+++ b/src/GUI/EFCorePowerTools/app.config
@@ -27,4 +27,4 @@
             </setting>
         </EFCorePowerTools.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/src/GUI/EFCorePowerTools/app.config
+++ b/src/GUI/EFCorePowerTools/app.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="EFCorePowerTools.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="EFCorePowerTools.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <userSettings>
@@ -27,4 +27,4 @@
             </setting>
         </EFCorePowerTools.Properties.Settings>
     </userSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/GUI/Shared/Options/OptionsPageGeneral.cs
+++ b/src/GUI/Shared/Options/OptionsPageGeneral.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 namespace EFCorePowerTools
 {
     [Guid(GuidList.guidOptionsPageGeneral)]
+    [ComVisible(true)]
     public class OptionsPageGeneral : DialogPage
     {
         protected override void OnActivate(CancelEventArgs e)

--- a/src/GUI/Shared/ViewModels/AboutViewModel.cs
+++ b/src/GUI/Shared/ViewModels/AboutViewModel.cs
@@ -2,8 +2,9 @@
 {
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Shared.BLL;
     using Shared.DAL;
     using Shared.Models;
@@ -11,7 +12,7 @@
     using System.ComponentModel;
     using System.Windows.Input;
 
-    public class AboutViewModel : ViewModelBase, IAboutViewModel
+    public class AboutViewModel : ObservableObject, IAboutViewModel
     {
         private readonly AboutExtensionModel _aboutExtensionModel;
         private readonly IExtensionVersionService _extensionVersionService;
@@ -33,7 +34,7 @@
             {
                 if (Equals(value, _version)) return;
                 _version = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 

--- a/src/GUI/Shared/ViewModels/AdvancedModelingOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/AdvancedModelingOptionsViewModel.cs
@@ -2,13 +2,14 @@
 {
     using Contracts.EventArgs;
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Shared.Models;
     using System;
     using System.Windows.Input;
 
-    public class AdvancedModelingOptionsViewModel : ViewModelBase, IAdvancedModelingOptionsViewModel
+    public class AdvancedModelingOptionsViewModel : ObservableObject, IAdvancedModelingOptionsViewModel
     {
         public event EventHandler<CloseRequestedEventArgs> CloseRequested;
 

--- a/src/GUI/Shared/ViewModels/ColumnInformationViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ColumnInformationViewModel.cs
@@ -3,13 +3,13 @@
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
     using EFCorePowerTools.Messages;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using System;
     using System.Windows.Input;
 
-    public class ColumnInformationViewModel : ViewModelBase, IColumnInformationViewModel
+    public class ColumnInformationViewModel : ObservableObject, IColumnInformationViewModel
     {
         private string _name;
         private string _newName;
@@ -39,7 +39,7 @@
             {
                 if (Equals(value, _name)) return;
                 _name = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -50,8 +50,8 @@
             {
                 if (Equals(value, _newName)) return;
                 _newName = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(DisplayName));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayName));
             }
         }
 
@@ -70,8 +70,8 @@
             {
                 if (Equals(value, _isPrimaryKey)) return;
                 _isPrimaryKey = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(IsEnabled));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsEnabled));
             }
         }
 
@@ -82,8 +82,8 @@
             {
                 if (Equals(value, _isForeignKey)) return;
                 _isForeignKey = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(IsEnabled));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsEnabled));
             }
         }
 
@@ -99,7 +99,7 @@
             {
                 if (Equals(value, _isSelected)) return;
                 _isSelected = value.Value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -110,7 +110,7 @@
             {
                 if (Equals(value, _isEditing)) return;
                 _isEditing = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -121,8 +121,8 @@
             {
                 if (Equals(value, _isTableSelected)) return;
                 _isTableSelected = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(IsEnabled));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsEnabled));
             }
         }
 

--- a/src/GUI/Shared/ViewModels/CompareLogItemViewModel.cs
+++ b/src/GUI/Shared/ViewModels/CompareLogItemViewModel.cs
@@ -1,16 +1,18 @@
 ﻿using EFCorePowerTools.Handlers.Compare;
-using GalaSoft.MvvmLight;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.Mvvm.Input;
 
 namespace EFCorePowerTools.ViewModels
 {
-    public class CompareLogItemViewModel : ViewModelBase
+    public class CompareLogItemViewModel : ObservableObject
     {
         private bool _visible;
         private bool _checked;
 
         public bool Visible
         {
-            get => _visible; set => Set(ref _visible, value);
+            get => _visible; set => SetProperty(ref _visible, value);
         }
         public int Level
         {
@@ -46,7 +48,7 @@ namespace EFCorePowerTools.ViewModels
         }
         public bool Checked
         {
-            get => _checked; set => Set(ref _checked, value);
+            get => _checked; set => SetProperty(ref _checked, value);
         }
     }
 }

--- a/src/GUI/Shared/ViewModels/CompareOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/CompareOptionsViewModel.cs
@@ -3,8 +3,9 @@
     using Contracts.EventArgs;
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Shared.DAL;
     using Shared.Models;
     using System;
@@ -13,7 +14,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class CompareOptionsViewModel : ViewModelBase, ICompareOptionsViewModel
+    public class CompareOptionsViewModel : ObservableObject, ICompareOptionsViewModel
     {
         private readonly IVisualStudioAccess _visualStudioAccess;
         private DatabaseConnectionModel _selectedDatabaseConnection;
@@ -43,7 +44,7 @@
         public DatabaseConnectionModel SelectedDatabaseConnection
         {
             get => _selectedDatabaseConnection;
-            set => Set(ref _selectedDatabaseConnection, value);
+            set => SetProperty(ref _selectedDatabaseConnection, value);
         }
 
         public CompareOptionsViewModel(IVisualStudioAccess visualStudioAccess)
@@ -133,7 +134,7 @@
         }
     }
 
-    public class ContextTypeItemViewModel : ViewModelBase
+    public class ContextTypeItemViewModel : ObservableObject
     {
         private bool _selected;
 
@@ -151,7 +152,7 @@
         public bool Selected
         {
             get => _selected;
-            set => Set(ref _selected, value);
+            set => SetProperty(ref _selected, value);
         }
     }
 }

--- a/src/GUI/Shared/ViewModels/CompareResultViewModel.cs
+++ b/src/GUI/Shared/ViewModels/CompareResultViewModel.cs
@@ -3,8 +3,9 @@
     using Contracts.EventArgs;
     using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.Handlers.Compare;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
@@ -12,7 +13,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class CompareResultViewModel : ViewModelBase, ICompareResultViewModel
+    public class CompareResultViewModel : ObservableObject, ICompareResultViewModel
     {
         private bool _showDifferencesOnly = true;
         private List<CompareLogItemViewModel> _completeLogs { get; } = new List<CompareLogItemViewModel>();
@@ -33,7 +34,7 @@
             get => _showDifferencesOnly;
             set
             {
-                Set(ref _showDifferencesOnly, value);
+                SetProperty(ref _showDifferencesOnly, value);
                 Logs.Clear();
                 var l = value ? _filteredLogs : _completeLogs;
                 foreach (var item in l)

--- a/src/GUI/Shared/ViewModels/MigrationOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/MigrationOptionsViewModel.cs
@@ -5,8 +5,9 @@
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
     using Extensions;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Handlers;
     using Microsoft.VisualStudio.Shell;
     using Shared.DAL;
@@ -18,7 +19,7 @@
     using System.Windows;
     using System.Windows.Input;
 
-    public class MigrationOptionsViewModel : ViewModelBase, IMigrationOptionsViewModel
+    public class MigrationOptionsViewModel : ObservableObject, IMigrationOptionsViewModel
     {
         private readonly IVisualStudioAccess _visualStudioAccess;
         private readonly RelayCommand _applyCommand;
@@ -46,7 +47,7 @@
             {
                 if (value == _title) return;
                 _title = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -57,7 +58,7 @@
             {
                 if (value == _applyButtonContent) return;
                 _applyButtonContent = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -68,7 +69,7 @@
             {
                 if (value == _statusList) return;
                 _statusList = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -80,7 +81,7 @@
                 if (value == _selectedStatusKey) return;
                 _selectedStatusKey = value;
                 HandleSelectedStatusKeyChange();
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -91,7 +92,7 @@
             {
                 if (value == _statusMessage) return;
                 _statusMessage = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -102,7 +103,7 @@
             {
                 if (value == _migrationName) return;
                 _migrationName = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -119,7 +120,7 @@
             {
                 if (Math.Abs(value - _backgroundOpacity) < double.Epsilon) return;
                 _backgroundOpacity = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -130,7 +131,7 @@
             {
                 if (value == _migrationNameVisibility) return;
                 _migrationNameVisibility = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -370,7 +371,7 @@
             try
             {
                 _applying = true;
-                _applyCommand.RaiseCanExecuteChanged();
+                _applyCommand.NotifyCanExecuteChanged();
                 await _visualStudioAccess.StartStatusBarAnimationAsync();
 
                 if (!StatusList.TryGetValue(SelectedStatusKey, out var selectedStatusValue))
@@ -405,7 +406,7 @@
                 await _visualStudioAccess.StopStatusBarAnimationAsync();
                 await _visualStudioAccess.SetStatusBarTextAsync(string.Empty);
                 _applying = false;
-                _applyCommand.RaiseCanExecuteChanged();
+                _applyCommand.NotifyCanExecuteChanged();
             }
         }
 

--- a/src/GUI/Shared/ViewModels/ModelingOptionsViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ModelingOptionsViewModel.cs
@@ -5,15 +5,16 @@ namespace EFCorePowerTools.ViewModels
     using Contracts.EventArgs;
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Shared.DAL;
     using Shared.Models;
     using System;
     using System.Collections.Generic;
     using System.Windows.Input;
 
-    public class ModelingOptionsViewModel : ViewModelBase, IModelingOptionsViewModel
+    public class ModelingOptionsViewModel : ObservableObject, IModelingOptionsViewModel
     {
         private readonly IVisualStudioAccess _visualStudioAccess;
         private readonly Func<IAdvancedModelingOptionsDialog> _advancedModelingOptionsDialogFactory;
@@ -38,7 +39,7 @@ namespace EFCorePowerTools.ViewModels
             {
                 if (value == _title) return;
                 _title = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -49,7 +50,7 @@ namespace EFCorePowerTools.ViewModels
             {
                 if (value == _mayIncludeConnectionString) return;
                 _mayIncludeConnectionString = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 

--- a/src/GUI/Shared/ViewModels/ObjectTreeRootItemViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ObjectTreeRootItemViewModel.cs
@@ -1,8 +1,9 @@
 ﻿namespace EFCorePowerTools.ViewModels
 {
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System;
     using System.Collections.ObjectModel;
@@ -10,7 +11,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class ObjectTreeRootItemViewModel : ViewModelBase, IObjectTreeRootItemViewModel
+    public class ObjectTreeRootItemViewModel : ObservableObject, IObjectTreeRootItemViewModel
     {
         public ObjectTreeRootItemViewModel()
         {
@@ -34,7 +35,7 @@
             {
                 if (Equals(value, IsSelected1)) return;
                 IsSelected1 = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 if (IsSelected1 != null)
                 {
                     var selected = IsSelected1.Value;
@@ -53,7 +54,7 @@
             {
                 if (Equals(value, Text1)) return;
                 Text1 = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -64,8 +65,8 @@
             {
                 if (Equals(value, ObjectType1)) return;
                 ObjectType1 = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(ObjectTypeIcon));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ObjectTypeIcon));
             }
         }
 
@@ -88,23 +89,23 @@
                 if (Schemas.All(m => m.IsSelected.GetValueOrDefault()))
                 {
                     IsSelected1 = true;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
                 else if (Schemas.All(m => m.IsSelected.HasValue && !m.IsSelected.Value))
                 {
                     IsSelected1 = false;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
                 else
                 {
                     IsSelected1 = null;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
             }
 
             if (e.PropertyName == nameof(ISchemaInformationViewModel.IsVisible))
             {
-                RaisePropertyChanged(nameof(IsVisible));
+                OnPropertyChanged(nameof(IsVisible));
             }
 
         }

--- a/src/GUI/Shared/ViewModels/ObjectTreeViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ObjectTreeViewModel.cs
@@ -2,7 +2,9 @@
 {
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
-    using GalaSoft.MvvmLight;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System;
     using System.Collections.Generic;
@@ -11,7 +13,7 @@
     using System.Linq;
     using System.Text.RegularExpressions;
 
-    public class ObjectTreeViewModel : ViewModelBase, IObjectTreeViewModel
+    public class ObjectTreeViewModel : ObservableObject, IObjectTreeViewModel
     {
         public event EventHandler ObjectSelectionChanged;
 

--- a/src/GUI/Shared/ViewModels/PickConfigViewModel.cs
+++ b/src/GUI/Shared/ViewModels/PickConfigViewModel.cs
@@ -3,8 +3,9 @@
     using Contracts.EventArgs;
     using Contracts.ViewModels;
     using Contracts.Views;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using Shared.DAL;
     using Shared.Models;
     using System;
@@ -12,7 +13,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class PickConfigViewModel : ViewModelBase, IPickConfigViewModel
+    public class PickConfigViewModel : ObservableObject, IPickConfigViewModel
     {
         private ConfigModel _selectedConfiguration;
 
@@ -31,7 +32,7 @@
             {
                 if (Equals(value, _selectedConfiguration)) return;
                 _selectedConfiguration = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -43,7 +44,7 @@
 
             Configurations = new ObservableCollection<ConfigModel>();
 
-            Configurations.CollectionChanged += (sender, args) => RaisePropertyChanged(nameof(Configurations));
+            Configurations.CollectionChanged += (sender, args) => OnPropertyChanged(nameof(Configurations));
         }
 
         private void Loaded_Executed()

--- a/src/GUI/Shared/ViewModels/PickConnectionViewModel.cs
+++ b/src/GUI/Shared/ViewModels/PickConnectionViewModel.cs
@@ -2,8 +2,9 @@
 {
     using Contracts.EventArgs;
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using JetBrains.Annotations;
     using RevEng.Shared;
     using Shared.Models;
@@ -12,7 +13,7 @@
     using System.Runtime.CompilerServices;
     using System.Windows.Input;
 
-    public class PickConnectionViewModel : ViewModelBase, IPickConnectionViewModel
+    public class PickConnectionViewModel : ObservableObject, IPickConnectionViewModel
     {
         private string _connectionString;
         private string _name;

--- a/src/GUI/Shared/ViewModels/PickSchemasViewModel.cs
+++ b/src/GUI/Shared/ViewModels/PickSchemasViewModel.cs
@@ -4,15 +4,16 @@ namespace EFCorePowerTools.ViewModels
 {
     using Contracts.EventArgs;
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System;
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Windows.Input;
 
-    public class PickSchemasViewModel : ViewModelBase, IPickSchemasViewModel
+    public class PickSchemasViewModel : ObservableObject, IPickSchemasViewModel
     {
         public event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
@@ -32,7 +33,7 @@ namespace EFCorePowerTools.ViewModels
             {
                 if (value == _selectedSchema) return;
                 _selectedSchema = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 

--- a/src/GUI/Shared/ViewModels/PickServerDatabaseViewModel.cs
+++ b/src/GUI/Shared/ViewModels/PickServerDatabaseViewModel.cs
@@ -5,8 +5,9 @@
     using Contracts.Views;
     using EFCorePowerTools.DAL;
     using EFCorePowerTools.Locales;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using Shared.DAL;
     using Shared.Models;
@@ -17,7 +18,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class PickServerDatabaseViewModel : ViewModelBase, IPickServerDatabaseViewModel
+    public class PickServerDatabaseViewModel : ObservableObject, IPickServerDatabaseViewModel
     {
         private readonly IVisualStudioAccess _visualStudioAccess;
         private readonly ICredentialStore _credentialStore;
@@ -54,7 +55,7 @@
             {
                 if (value == _codeGenerationMode) return;
                 _codeGenerationMode = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -65,7 +66,7 @@
             {
                 if (value == _filterSchemas) return;
                 _filterSchemas = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -76,7 +77,7 @@
             {
                 if (Equals(value, _selectedDatabaseConnection)) return;
                 _selectedDatabaseConnection = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
 
                 if (_selectedDatabaseConnection != null)
                     SelectedDatabaseDefinition = null;
@@ -90,7 +91,7 @@
             {
                 if (Equals(value, _selectedDatabaseDefinition)) return;
                 _selectedDatabaseDefinition = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
 
                 if (_selectedDatabaseDefinition != null)
                     SelectedDatabaseConnection = null;
@@ -155,7 +156,7 @@
             DatabaseConnections = new ObservableCollection<DatabaseConnectionModel>();
             DatabaseDefinitions = new ObservableCollection<DatabaseDefinitionModel>();
             Schemas = new List<SchemaInfo>();
-            DatabaseDefinitions.CollectionChanged += (sender, args) => RaisePropertyChanged(nameof(DatabaseDefinitions));
+            DatabaseDefinitions.CollectionChanged += (sender, args) => OnPropertyChanged(nameof(DatabaseDefinitions));
         }
 
         private void Loaded_Executed()

--- a/src/GUI/Shared/ViewModels/PickTablesViewModel.cs
+++ b/src/GUI/Shared/ViewModels/PickTablesViewModel.cs
@@ -2,8 +2,9 @@
 {
     using Contracts.EventArgs;
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System;
     using System.Collections.Generic;
@@ -12,7 +13,7 @@
     using System.Threading.Tasks;
     using System.Windows.Input;
 
-    public class PickTablesViewModel : ViewModelBase, IPickTablesViewModel
+    public class PickTablesViewModel : ObservableObject, IPickTablesViewModel
     {
 
         private bool? _tableSelectionThreeState;
@@ -44,7 +45,7 @@
             {
                 if (Equals(value, _tableSelectionThreeState)) return;
                 _tableSelectionThreeState = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 HandleTableSelectionThreeStateChange(value);
             }
         }
@@ -56,7 +57,7 @@
             {
                 if (Equals(value, _searchText)) return;
                 _searchText = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 HandleSearchTextChange(_searchText, _searchMode);
             }
         }
@@ -68,7 +69,7 @@
             {
                 if (Equals(value, _searchMode)) return;
                 _searchMode = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 HandleSearchTextChange(_searchText, _searchMode);
             }
         }

--- a/src/GUI/Shared/ViewModels/SchemaInformationViewModel.cs
+++ b/src/GUI/Shared/ViewModels/SchemaInformationViewModel.cs
@@ -1,15 +1,16 @@
 ﻿namespace EFCorePowerTools.ViewModels
 {
     using Contracts.ViewModels;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Linq;
     using System.Windows.Input;
 
-    public class SchemaInformationViewModel : ViewModelBase, ISchemaInformationViewModel
+    public class SchemaInformationViewModel : ObservableObject, ISchemaInformationViewModel
     {
         private string _name;
         private bool? _isSelected = false;
@@ -31,7 +32,7 @@
             {
                 if (Equals(value, _name)) return;
                 _name = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -44,7 +45,7 @@
             {
                 if (Equals(value, _isSelected)) return;
                 _isSelected = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 if (_isSelected != null)
                 {
                     var selected = _isSelected.Value;
@@ -73,23 +74,23 @@
                 if (Objects.All(m => m.IsSelected.Value))
                 {
                     _isSelected = true;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
                 else if (Objects.All(m => !m.IsSelected.Value))
                 {
                     _isSelected = false;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
                 else
                 {
                     _isSelected = null;
-                    RaisePropertyChanged(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
             }
 
             if (e.PropertyName == nameof(ISchemaInformationViewModel.IsVisible))
             {
-                RaisePropertyChanged(nameof(IsVisible));
+                OnPropertyChanged(nameof(IsVisible));
             }
 
         }

--- a/src/GUI/Shared/ViewModels/TableInformationViewModel.cs
+++ b/src/GUI/Shared/ViewModels/TableInformationViewModel.cs
@@ -3,9 +3,9 @@
     using Contracts.ViewModels;
     using EFCorePowerTools.Locales;
     using EFCorePowerTools.Messages;
-    using GalaSoft.MvvmLight;
-    using GalaSoft.MvvmLight.CommandWpf;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.ComponentModel;
+    using CommunityToolkit.Mvvm.Messaging;
+    using CommunityToolkit.Mvvm.Input;
     using RevEng.Shared;
     using System;
     using System.Collections.ObjectModel;
@@ -13,7 +13,7 @@
     using System.Linq;
     using System.Windows.Input;
 
-    public class TableInformationViewModel : ViewModelBase, ITableInformationViewModel
+    public class TableInformationViewModel : ObservableObject, ITableInformationViewModel
     {
         private string _name;
         private string _newName;
@@ -44,7 +44,7 @@
             {
                 if (Equals(value, _schema)) return;
                 _schema = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -55,8 +55,8 @@
             {
                 if (Equals(value, _name)) return;
                 _name = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(DisplayName));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayName));
             }
         }
 
@@ -67,8 +67,8 @@
             {
                 if (Equals(value, _newName)) return;
                 _newName = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(DisplayName));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayName));
             }
         }
 
@@ -93,8 +93,8 @@
             {
                 if (Equals(value, _objectType)) return;
                 _objectType = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(ObjectTypeIcon));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ObjectTypeIcon));
             }
         }
 
@@ -122,7 +122,7 @@
             {
                 if (Equals(value, _isSelected)) return;
                 _isSelected = value.Value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
                 foreach (var column in Columns)
                 {
                     column.IsTableSelected = _isSelected;
@@ -138,7 +138,7 @@
             {
                 if (Equals(value, _isVisible)) return;
                 _isVisible = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -149,7 +149,7 @@
             {
                 if (Equals(value, _isEditing)) return;
                 _isEditing = value;
-                RaisePropertyChanged();
+                OnPropertyChanged();
             }
         }
 
@@ -191,7 +191,7 @@
         {
             foreach (var item in e.NewItems)
             {
-                RaisePropertyChanged(nameof(HasPrimaryKey));
+                OnPropertyChanged(nameof(HasPrimaryKey));
             }
         }
 

--- a/src/GUI/UnitTests/UnitTests.csproj
+++ b/src/GUI/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -101,8 +101,8 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Data.Framework">
-      <Version>17.0.32112.339</Version>
+    <PackageReference Include="Microsoft.VisualStudio.Data">
+      <Version>16.10.31320.204</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.15.2</Version>

--- a/src/GUI/UnitTests/UnitTests.csproj
+++ b/src/GUI/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -102,13 +102,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Data.Framework">
-      <Version>16.9.31025.104</Version>
+      <Version>17.0.32112.339</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.15.2</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmLightLibs">
-      <Version>5.4.1.1</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.12.0</Version>

--- a/src/GUI/UnitTests/ViewModels/ColumnInformationViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/ColumnInformationViewModelTests.cs
@@ -3,7 +3,7 @@
 namespace UnitTests.ViewModels
 {
     using EFCorePowerTools.ViewModels;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.Messaging;
     using Moq;
 
     [TestFixture]

--- a/src/GUI/UnitTests/ViewModels/ObjectTreeRootItemViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/ObjectTreeRootItemViewModelTests.cs
@@ -4,7 +4,7 @@ namespace UnitTests.ViewModels
 {
     using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.ViewModels;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.Messaging;
     using Moq;
     using System.Linq;
 

--- a/src/GUI/UnitTests/ViewModels/ObjectTreeViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/ObjectTreeViewModelTests.cs
@@ -4,7 +4,7 @@ namespace UnitTests.ViewModels
 {
     using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.ViewModels;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.Messaging;
     using Moq;
     using RevEng.Shared;
     using System;

--- a/src/GUI/UnitTests/ViewModels/SchemaInformationViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/SchemaInformationViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using Moq;
 using NUnit.Framework;
 

--- a/src/GUI/UnitTests/ViewModels/TableInformationViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/TableInformationViewModelTests.cs
@@ -4,7 +4,7 @@ namespace UnitTests.ViewModels
 {
     using EFCorePowerTools.Contracts.ViewModels;
     using EFCorePowerTools.ViewModels;
-    using GalaSoft.MvvmLight.Messaging;
+    using CommunityToolkit.Mvvm.Messaging;
     using Moq;
     using RevEng.Shared;
     using System.Linq;


### PR DESCRIPTION
- EFCorePowerTools + Tests -  Moved to .NET 4.8
- 
- Removed Unused nuget VSSDK from EFCore and Tests

- Replaced GalaSoft MVVM deprecated nugets with Community.Mvvm (
Refactoring all ViewModels
ViewModelBase => ObservableObject
RaisePropertyChanged() => OnPropertyChanged()
Set(ref field, value ) => SetProperty
EFCoreTools - ServiceProvider -> using Mvvm.WeakMessagener instead of old Messenger
)

- Upgraded EFCorePowerTools to use Community.VisualStudio.Tookit 17

- Had to add Comvisible(true) to OptionsPageGeneral othwerwise it was not building at all, even without any of my changes

- Run all the tests