### PR TITLE
Fixes ErikEJ#1848. Duplicate semicolons in dbcontext file

### DIFF
--- a/src/GUI/RevEng.Core.60/ReverseEngineerScaffolder.cs
+++ b/src/GUI/RevEng.Core.60/ReverseEngineerScaffolder.cs
@@ -383,7 +383,14 @@ namespace RevEng.Core
                     {
                         sb.Append(usingKeyWord);
                         sb.Append(codeFileNamespace);
-                        sb.AppendLine(";");
+                        var usingEndLineCharacter = ";";
+                        var cSharp10UsingStyle = codeFileNamespace.EndsWith(';');
+                        if (cSharp10UsingStyle)
+                        {
+                            usingEndLineCharacter = string.Empty;
+                        }
+
+                        sb.AppendLine(usingEndLineCharacter);
                     }
                 }
                 else


### PR DESCRIPTION
# Fix for duplicate semicolons in dbcontext file

Fix for duplicate semicolons in dbcontext file when using database schema namespaces and EF7 that uses C#10 using styles.

Fixes #1848 

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Generating the files using Adventure Worker database with the `efreveng60` and `efreveng70` project versions.