### PR TITLE
Issue #2100  - Adds new option to not refresh the object lists in the efcpt-config.json during subsequent scaffolds

### DIFF
--- a/samples/efcpt-config.json
+++ b/samples/efcpt-config.json
@@ -55,7 +55,8 @@
      "use-alternate-stored-procedure-resultset-discovery": false,
      "t4-template-path": null,
      "use-no-navigations-preview": false,
-     "merge-dacpacs": false
+     "merge-dacpacs": false,
+     "refresh-object-lists": false
   },
   "names":
   {

--- a/samples/efcpt-schema.json
+++ b/samples/efcpt-schema.json
@@ -380,6 +380,14 @@
                     "examples": [
                         false
                     ]
+                },
+                "refresh-object-lists": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "Generate the refresh the lists of objects (tables, views, stored procedures, functions) from the database in the config file during scaffolding",
+                    "examples": [
+                        false
+                    ]
                 }
             },
             "examples": [{
@@ -398,7 +406,8 @@
                 "use-alternate-stored-procedure-resultset-discovery": false,
                 "use-no-navigations-preview": false,
                 "merge-dacpacs": false,
-                "remove-valuegeneratedonadd": false
+                "remove-valuegeneratedonadd": false,
+                "refresh-object-lists": true
             }]
         },
         "names": {
@@ -634,7 +643,8 @@
             "remove-defaultsql-from-bool-properties": false,
             "soft-delete-obsolete-files": false,
             "discover-multiple-stored-procedure-resultsets-preview": false,
-            "use-alternate-stored-procedure-resultset-discovery": false
+            "use-alternate-stored-procedure-resultset-discovery": false,
+            "refresh-object-lists": true
         },
         "names": {
             "root-namespace": "MyProject",

--- a/src/Core/NUnitTestCore/CliObjectListTest.cs
+++ b/src/Core/NUnitTestCore/CliObjectListTest.cs
@@ -14,6 +14,18 @@ namespace UnitTests
     [TestFixture]
     public class CliObjectListTest
     {
+
+        private readonly string cliTestDirectory =
+            Path.Combine(TestContext.CurrentContext.TestDirectory, "CliObjectListTests");
+
+        [SetUp]
+        public void Setup()
+        {
+
+            if (!Directory.Exists(cliTestDirectory))
+                Directory.CreateDirectory(cliTestDirectory);
+        }
+
         [Test]
         public void CanGetConfig()
         {
@@ -238,7 +250,7 @@ namespace UnitTests
 
         private string TestPath(string file)
         {
-            return System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, "Dacpac", file);
+            return System.IO.Path.Combine(cliTestDirectory, file);
         }
 
         private CliConfig GetConfig()

--- a/src/Core/NUnitTestCore/CliObjectListTest.cs
+++ b/src/Core/NUnitTestCore/CliObjectListTest.cs
@@ -1,5 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
 using NUnit.Framework;
+using RevEng.Common;
 using RevEng.Common.Cli;
 using RevEng.Common.Cli.Configuration;
 
@@ -136,6 +142,103 @@ namespace UnitTests
             Assert.NotNull(result);
 
             Assert.AreEqual(4, result.Count);
+        }
+
+        [Test]
+        public void TryGetCliConfigWithExistingFileReturnsExpectedConfig()
+        {
+            var config = GetConfig();
+            var testPath = TestPath("test.efpcli.json");
+            try
+            {
+                WriteConfigFile(config, testPath);
+
+                var fetchedConfigSuccess = CliConfigMapper.TryGetCliConfig(testPath, "fakeConnectionString",
+                    DatabaseType.SQLServer,
+                    () => GetDefaultTables(DatabaseType.SQLServer), CodeGenerationMode.EFCore7,
+                    out CliConfig resultConfig);
+
+                Assert.True(fetchedConfigSuccess);
+
+                Assert.NotNull(resultConfig);
+
+                Assert.True(config.Tables.Count == resultConfig.Tables.Count);
+
+                for (var i = 0; i < config.Tables.Count; i++)
+                {
+                    Assert.AreEqual(config.Tables[i].Name, resultConfig.Tables[i].Name);
+                    Assert.AreEqual(config.Tables[i].Exclude, resultConfig.Tables[i].Exclude);
+                    Assert.AreEqual(config.Tables[i].ExclusionWildcard, resultConfig.Tables[i].ExclusionWildcard);
+                }
+            }
+            finally
+            {
+                RemoveConfigFile(testPath);
+            }
+        }
+
+        [Test]
+        public void TryGetCliConfigWithoutRefreshDoesNotRefreshObjectList()
+        {
+            var config = GetConfig();
+            config.Tables.RemoveRange(2,3);
+            config.CodeGeneration.RefreshObjectLists = false;
+            var testPath = TestPath("test.efpcli.json");
+
+            try
+            {
+                WriteConfigFile(config, testPath);
+
+                var fetchedConfigSuccess = CliConfigMapper.TryGetCliConfig(testPath, "fakeConnectionString",
+                    DatabaseType.SQLServer,
+                    () => throw new Exception(), CodeGenerationMode.EFCore7,
+                    out CliConfig resultConfig);
+
+                Assert.True(fetchedConfigSuccess);
+
+                Assert.NotNull(resultConfig);
+
+                Assert.True(config.Tables.Count == resultConfig.Tables.Count);
+
+                for (var i = 0; i < config.Tables.Count; i++)
+                {
+                    Assert.AreEqual(config.Tables[i].Name, resultConfig.Tables[i].Name);
+                    Assert.AreEqual(config.Tables[i].Exclude, resultConfig.Tables[i].Exclude);
+                    Assert.AreEqual(config.Tables[i].ExclusionWildcard, resultConfig.Tables[i].ExclusionWildcard);
+                }
+            }
+            finally
+            {
+                RemoveConfigFile(testPath);
+            }
+        }
+
+        private static List<TableModel> GetDefaultTables(DatabaseType databaseType)
+        {
+            return new List<TableModel>()
+            {
+                new TableModel("Users", "dbo", databaseType, ObjectType.Table, new List<ColumnModel>()),
+                new TableModel("Accounts", "other", databaseType, ObjectType.Table, new List<ColumnModel>()),
+                new TableModel("Extras", "dbo", databaseType, ObjectType.Table, new List<ColumnModel>()),
+                new TableModel("Actors", "dbo", databaseType, ObjectType.Table, new List<ColumnModel>()),
+                new TableModel("Directors", "dbo", databaseType, ObjectType.Table, new List<ColumnModel>()),
+            };
+        }
+
+        private void WriteConfigFile(CliConfig configToWrite, string fullPath)
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(fullPath, JsonSerializer.Serialize(configToWrite, options), Encoding.UTF8);
+        }
+
+        private void RemoveConfigFile(string fullPath)
+        {
+            File.Delete(fullPath);
+        }
+
+        private string TestPath(string file)
+        {
+            return System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, "Dacpac", file);
         }
 
         private CliConfig GetConfig()

--- a/src/Core/efcpt.7/HostedServices/ScaffoldHostedService.cs
+++ b/src/Core/efcpt.7/HostedServices/ScaffoldHostedService.cs
@@ -39,22 +39,11 @@ internal sealed class ScaffoldHostedService : HostedService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
-        var sw = Stopwatch.StartNew();
-        var tableModels = GetTablesAndViews();
-        GetProcedures(tableModels);
-        GetFunctions(tableModels);
-        sw.Stop();
-
-        DisplayService.MarkupLine();
-        DisplayService.MarkupLine(
-            $"{tableModels.Count} database objects discovered in {sw.Elapsed.TotalSeconds:0.0} seconds",
-            Color.Default);
-
         if (!CliConfigMapper.TryGetCliConfig(
                 scaffoldOptions.ConfigFile.FullName,
                 scaffoldOptions.ConnectionString,
                 reverseEngineerCommandOptions.DatabaseType,
-                tableModels,
+                GetModels,
                 Constants.CodeGeneration,
                 out var config))
         {
@@ -85,7 +74,7 @@ internal sealed class ScaffoldHostedService : HostedService
 #pragma warning restore S2583 // Conditionally executed code should be reachable
 #pragma warning restore S2589 // Boolean expressions should not be gratuitous
 
-        sw = Stopwatch.StartNew();
+        var sw = Stopwatch.StartNew();
         var result = DisplayService.Wait(
             "Generating EF Core DbContext and entity classes...",
             () => ReverseEngineerRunner.GenerateFiles(commandOptions)) ?? new ReverseEngineerResult();
@@ -114,6 +103,19 @@ internal sealed class ScaffoldHostedService : HostedService
         DisplayService.MarkupLine();
 
         Environment.ExitCode = 0;
+     
+        List<TableModel> GetModels()
+        {
+            var sw = Stopwatch.StartNew();
+            var tableModels = GetTablesAndViews();
+            GetProcedures(tableModels);
+            GetFunctions(tableModels);
+            sw.Stop();
+
+            DisplayService.MarkupLine();
+            DisplayService.MarkupLine($"{tableModels.Count} database objects discovered in {sw.Elapsed.TotalSeconds:0.0} seconds", Color.Default);
+            return tableModels;
+        }
     }
 
     private static void ShowPaths(List<string> paths)

--- a/src/Core/efcpt.7/readme.md
+++ b/src/Core/efcpt.7/readme.md
@@ -52,7 +52,7 @@ If you have updated the configuration file in a way that requires files to be de
 
 ### Excluding objects
 
-The config file will always contain all current database objects. 
+The config file defaults to always contain all current database objects.  If you don't want the objects lists to be refreshed during each scaffolding operation, set the `"refresh-object-lists"` option to `false` in the configuration file.
 
 You can exclude indvidual database objects with `"exclude": true` for the object.
 

--- a/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
+++ b/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
@@ -110,7 +110,7 @@ namespace RevEng.Common.Cli
             return options;
         }
 
-        public static bool TryGetCliConfig(string fullPath, string connectionString, DatabaseType databaseType, List<TableModel> objects, CodeGenerationMode codeGenerationMode, out CliConfig config)
+        public static bool TryGetCliConfig(string fullPath, string connectionString, DatabaseType databaseType, Func<List<TableModel>> objectGenerator, CodeGenerationMode codeGenerationMode, out CliConfig config)
         {
             if (File.Exists(fullPath))
             {
@@ -136,10 +136,19 @@ namespace RevEng.Common.Cli
                 }
             }
 
-            config.Tables = Add(objects, config.Tables);
-            config.Views = Add(objects, config.Views);
-            config.StoredProcedures = Add(objects, config.StoredProcedures);
-            config.Functions = Add(objects, config.Functions);
+            if (config.CodeGeneration.RefreshObjectLists)
+            {
+                if (objectGenerator == null)
+                {
+                    throw new ArgumentNullException(nameof(objectGenerator));
+                }
+
+                var objects = objectGenerator.Invoke();
+                config.Tables = Add(objects, config.Tables);
+                config.Views = Add(objects, config.Views);
+                config.StoredProcedures = Add(objects, config.StoredProcedures);
+                config.Functions = Add(objects, config.Functions);
+            }
 
 #pragma warning disable CA1869 // Cache and reuse 'JsonSerializerOptions' instances
             var options = new JsonSerializerOptions { WriteIndented = true };

--- a/src/GUI/RevEng.Shared/Cli/Configuration/CodeGeneration.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/CodeGeneration.cs
@@ -62,5 +62,8 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonPropertyName("generate-mermaid-diagram")]
         public bool GenerateMermaidDiagram { get; set; }
+
+        [JsonPropertyName("refresh-object-lists")]
+        public bool RefreshObjectLists { get; set; } = true;
     }
 }


### PR DESCRIPTION
Adds new option to not refresh the object lists in the efcpt-config.json during subsequent scaffolds.  Useful when only scaffolding a small number of tables from a database that has many tables in it that are being excluded.  Closes #2100.