### PR TITLE
Add ability to exclude columns in the CLI config (feature exists in VS Plugin, adding for parity)

### DIFF
--- a/samples/efcpt-schema.json
+++ b/samples/efcpt-schema.json
@@ -42,6 +42,25 @@
                         "examples": [
                             "*"
                         ]
+                    },
+                    "excludedColumns": {
+                        "type": "array",
+                        "default": [],
+                        "title": "Columns to Exclude from code generation",
+                        "items": {
+                            "type": "string",
+                            "title": "Column",
+                            "examples": [
+                                "Name",
+                                "Email"
+                            ]
+                        },
+                        "examples": [
+                            [
+                                "Name",
+                                "Email"
+                            ]
+                        ]
                     }
                 },
                 "examples": [{
@@ -91,6 +110,25 @@
                         "title": "Exclusion pattern with * symbol, use '*' to exclude all by default",
                         "examples": [
                             "*"
+                        ]
+                    },
+                    "excludedColumns": {
+                        "type": "array",
+                        "default": [],
+                        "title": "Columns to Exclude from code generation",
+                        "items": {
+                            "type": "string",
+                            "title": "Column",
+                            "examples": [
+                                "Name",
+                                "Email"
+                            ]
+                        },
+                        "examples": [
+                            [
+                                "Name",
+                                "Email"
+                            ]
                         ]
                     }
                 },
@@ -603,7 +641,8 @@
             "name": "[dbo].[Categories]"
         },
         {
-            "name": "[dbo].[CustomerCustomerDemo]"
+            "name": "[dbo].[CustomerCustomerDemo]",
+            "excludedColumns": ["Name", "Email"]
         },
         {
             "name": "[dbo].[Oldtable]",
@@ -613,7 +652,8 @@
             "name": "[dbo].[Categories]"
         },
         {
-            "name": "[dbo].[CustomerCustomerDemo]"
+            "name": "[dbo].[CustomerCustomerDemo]",
+            "excludedColumns": ["Name", "Email"]
         }],
         "stored-procedures": [{
             "name": "[dbo].[Alphabetical list of products]"

--- a/src/Core/NUnitTestCore/CliObjectListTest.cs
+++ b/src/Core/NUnitTestCore/CliObjectListTest.cs
@@ -35,7 +35,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(5, result.Count);
+            Assert.AreEqual(6, result.Count);
         }
 
         [Test]
@@ -43,6 +43,7 @@ namespace UnitTests
         {
             var config = GetConfig();
 
+            config.Views.Add(new View { ExclusionWildcard = "*" });
             config.Tables.Add(new Table { ExclusionWildcard = "*" });
 
             var result = CliConfigMapper.BuildObjectList(config);
@@ -63,7 +64,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(2, result.Count);
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(4, result.Count);
+            Assert.AreEqual(5, result.Count);
         }
 
         [Test]
@@ -93,7 +94,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(3, result.Count);
         }
 
         [Test]
@@ -107,7 +108,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual(4, result.Count);
         }
 
         [Test]
@@ -123,7 +124,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual(4, result.Count);
         }
 
         [Test]
@@ -137,7 +138,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual(4, result.Count);
         }
 
         [Test]
@@ -153,7 +154,7 @@ namespace UnitTests
 
             Assert.NotNull(result);
 
-            Assert.AreEqual(4, result.Count);
+            Assert.AreEqual(5, result.Count);
         }
 
         [Test]

--- a/src/Core/NUnitTestCore/CliObjectListTest.cs
+++ b/src/Core/NUnitTestCore/CliObjectListTest.cs
@@ -167,43 +167,7 @@ namespace UnitTests
 
                 var fetchedConfigSuccess = CliConfigMapper.TryGetCliConfig(testPath, "fakeConnectionString",
                     DatabaseType.SQLServer,
-                    () => GetDefaultTables(DatabaseType.SQLServer), CodeGenerationMode.EFCore7,
-                    out CliConfig resultConfig);
-
-                Assert.True(fetchedConfigSuccess);
-
-                Assert.NotNull(resultConfig);
-
-                Assert.True(config.Tables.Count == resultConfig.Tables.Count);
-
-                for (var i = 0; i < config.Tables.Count; i++)
-                {
-                    Assert.AreEqual(config.Tables[i].Name, resultConfig.Tables[i].Name);
-                    Assert.AreEqual(config.Tables[i].Exclude, resultConfig.Tables[i].Exclude);
-                    Assert.AreEqual(config.Tables[i].ExclusionWildcard, resultConfig.Tables[i].ExclusionWildcard);
-                }
-            }
-            finally
-            {
-                RemoveConfigFile(testPath);
-            }
-        }
-
-        [Test]
-        public void TryGetCliConfigWithoutRefreshDoesNotRefreshObjectList()
-        {
-            var config = GetConfig();
-            config.Tables.RemoveRange(2,3);
-            config.CodeGeneration.RefreshObjectLists = false;
-            var testPath = TestPath("test.efpcli.json");
-
-            try
-            {
-                WriteConfigFile(config, testPath);
-
-                var fetchedConfigSuccess = CliConfigMapper.TryGetCliConfig(testPath, "fakeConnectionString",
-                    DatabaseType.SQLServer,
-                    () => throw new Exception(), CodeGenerationMode.EFCore7,
+                    GetDefaultTables(DatabaseType.SQLServer), CodeGenerationMode.EFCore7,
                     out CliConfig resultConfig);
 
                 Assert.True(fetchedConfigSuccess);

--- a/src/Core/efcpt.7/HostedServices/ScaffoldHostedService.cs
+++ b/src/Core/efcpt.7/HostedServices/ScaffoldHostedService.cs
@@ -56,7 +56,8 @@ internal sealed class ScaffoldHostedService : HostedService
                 reverseEngineerCommandOptions.DatabaseType,
                 tableModels,
                 Constants.CodeGeneration,
-                out var config))
+                out var config,
+                out var configWarnings))
         {
             Environment.ExitCode = 1;
             return;
@@ -98,6 +99,8 @@ internal sealed class ScaffoldHostedService : HostedService
         var paths = GetPaths(result);
         ShowPaths(paths);
         DisplayService.MarkupLine();
+
+        result.EntityWarnings.AddRange(configWarnings);
 
         ShowErrors(result);
         ShowWarnings(result);

--- a/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
+++ b/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
@@ -155,7 +155,7 @@ namespace RevEng.Common.Cli
         }
 
         /// <summary>
-        /// Ensures that any excluded columns for tables are not required
+        /// Ensures that any excluded columns for tables are not required. Removes the invalid columns from the list.
         /// </summary>
         /// <param name="config">Configuration to Validate.</param>
         /// <param name="objects">Table Models to check against.</param>

--- a/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
+++ b/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
@@ -170,13 +170,13 @@ namespace RevEng.Common.Cli
             foreach (var table in objectsToCheck)
             {
                 var dbTable = objects.Single(x => x.DisplayName == table.Name);
-                var columnsThatCannotBeExcluded = dbTable.Columns.Where(x => x.IsForeignKey || x.IsPrimaryKey).Select(x => x.Name.ToUpperInvariant());
+                var columnsThatCannotBeExcluded = dbTable.Columns.Where(x => x.IsForeignKey || x.IsPrimaryKey).Select(x => x.Name);
 
-                var badExclusions = columnsThatCannotBeExcluded.Intersect(table.ExcludedColumns.Select(c => c.ToUpperInvariant()));
+                var badExclusions = columnsThatCannotBeExcluded.Intersect(table.ExcludedColumns);
 
                 foreach (var column in badExclusions)
                 {
-                    var originalColumnString = table.ExcludedColumns.Single(x => string.Equals(x, column, StringComparison.InvariantCultureIgnoreCase));
+                    var originalColumnString = table.ExcludedColumns.Single(x => string.Equals(x, column, StringComparison.Ordinal));
                     warnings.Add($"{table.Name}.{originalColumnString} cannot be excluded because it is either a Primary Key or Foreign Key of another Mapped Column.  This entry has been removed from the config file.");
                     table.ExcludedColumns.Remove(originalColumnString);
                 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
@@ -17,5 +17,9 @@ namespace RevEng.Common.Cli.Configuration
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("excludedColumns")]
+        public string[] ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace RevEng.Common.Cli.Configuration
 {
@@ -18,8 +19,7 @@ namespace RevEng.Common.Cli.Configuration
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
 
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        [JsonPropertyName("excludedColumns")]
-        public string[] ExcludedColumns { get; set; }
+        [JsonIgnore] 
+        public List<string> ExcludedColumns { get; set; } = null;
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
@@ -7,4 +7,6 @@ public interface IEntity
     bool? Exclude { get; set; }
 
     string ExclusionWildcard { get; set; }
+
+    string[] ExcludedColumns { get; set; }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
@@ -1,4 +1,6 @@
-﻿namespace RevEng.Common.Cli.Configuration;
+﻿using System.Collections.Generic;
+
+namespace RevEng.Common.Cli.Configuration;
 
 public interface IEntity
 {
@@ -8,5 +10,5 @@ public interface IEntity
 
     string ExclusionWildcard { get; set; }
 
-    string[] ExcludedColumns { get; set; }
+    List<string> ExcludedColumns { get; set; }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace RevEng.Common.Cli.Configuration
 {
@@ -24,8 +25,7 @@ namespace RevEng.Common.Cli.Configuration
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
 
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        [JsonPropertyName("excludedColumns")]
-        public string[] ExcludedColumns { get; set; }
+        [JsonIgnore]
+        public List<string> ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
@@ -23,5 +23,9 @@ namespace RevEng.Common.Cli.Configuration
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("excludedColumns")]
+        public string[] ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
@@ -15,5 +15,9 @@ namespace RevEng.Common.Cli.Configuration
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("excludedColumns")]
+        public string[] ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
@@ -19,6 +19,6 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("excludedColumns")]
-        public List<string> ExcludedColumns { get; set; }
+        public List<string> ExcludedColumns { get; set; } = null;
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace RevEng.Common.Cli.Configuration
 {
@@ -18,6 +19,6 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("excludedColumns")]
-        public string[] ExcludedColumns { get; set; }
+        public List<string> ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
@@ -15,5 +15,9 @@ namespace RevEng.Common.Cli.Configuration
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("exclusionWildcard")]
         public string ExclusionWildcard { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("excludedColumns")]
+        public string[] ExcludedColumns { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace RevEng.Common.Cli.Configuration
 {
@@ -18,6 +19,6 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("excludedColumns")]
-        public string[] ExcludedColumns { get; set; }
+        public List<string> ExcludedColumns { get; set; } = null;
     }
 }


### PR DESCRIPTION
* Closes #2106 and adds the functionality for it. 

* Reverts part of #2104 in order to support the ability to have excluded columns in the CLI.  The reverted portion is the skipping of fetching the schema definition when the `refresh-object-list` is `false`