### PR TITLE
Use named parameters in MSSQL stored procedure scaffolding

### DIFF
--- a/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -301,7 +301,7 @@ namespace RevEng.Core.Procedures
         private static string GenerateProcedureStatement(Routine procedure, string retValueName, bool useAsyncCalls)
         {
             var paramList = procedure.Parameters
-                .Select(p => p.Output ? $"@{p.Name} OUTPUT" : $"@{p.Name}").ToList();
+                .Select(p => $"@{p.Name} = {p.Output ? "@{p.Name} OUTPUT" : "@{p.Name}").ToList();
 
             paramList.RemoveAt(paramList.Count - 1);
 

--- a/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -301,7 +301,7 @@ namespace RevEng.Core.Procedures
         private static string GenerateProcedureStatement(Routine procedure, string retValueName, bool useAsyncCalls)
         {
             var paramList = procedure.Parameters
-                .Select(p => $"@{p.Name} = @{p.Name}{(p.Output ? " OUTPUT" : "")}").ToList();
+                .Select(p => $"@{p.Name} = @{p.Name}{(p.Output ? " OUTPUT" : string.Empty)}").ToList();
 
             paramList.RemoveAt(paramList.Count - 1);
 

--- a/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -301,7 +301,7 @@ namespace RevEng.Core.Procedures
         private static string GenerateProcedureStatement(Routine procedure, string retValueName, bool useAsyncCalls)
         {
             var paramList = procedure.Parameters
-                .Select(p => $"@{p.Name} = {p.Output ? "@{p.Name} OUTPUT" : "@{p.Name}").ToList();
+                .Select(p => $"@{p.Name} = @{p.Name}{(p.Output ? " OUTPUT" : "")}").ToList();
 
             paramList.RemoveAt(paramList.Count - 1);
 


### PR DESCRIPTION
The earlier behavior generated the procedure call as `EXEC @returnValue = [dbo].[MyProc] @Param1, @Param2`

This PR changes the call to use named parameters, so we're not dependent on the order of parameters in the procedure call: `EXEC @returnValue = [dbo].[MyProc] @Param1=@Param1, @Param2=@Param2`

Fixes: #2258 

Tested via the CLI, which generates valid code for both normal and output variables:
`EXEC @returnValue = [dbo].[USP_ProcedureName] @SomeParam = @SomeParam, @OutputParam = @OutputParam OUTPUT...`