### PR TITLE
fix: #2261 set nullable annotation for procedure files

### DIFF
--- a/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.60/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -52,6 +52,7 @@ namespace RevEng.Core.Procedures
             Sb = new IndentedStringBuilder();
 
             Sb.AppendLine(PathHelper.Header);
+            Sb.AppendLine("#nullable disable"); // procedure parameters are always nullable
 
             var usings = CreateUsings(scaffolderOptions, model, schemas);
 
@@ -158,6 +159,7 @@ namespace RevEng.Core.Procedures
             Sb = new IndentedStringBuilder();
 
             Sb.AppendLine(PathHelper.Header);
+            Sb.AppendLine("#nullable disable"); // procedure parameters are always nullable
 
             var usings = CreateUsings(scaffolderOptions, model, schemas);
 


### PR DESCRIPTION
Since the procedure parameters are always nullable, set the `#nullable disable` annotation to the relevant files to reduce conflicts with projects using nullable reference types


Tested with the CLI - generates the expected annotations to the top of the two files - the interface definition and the implementation:

```
// <auto-generated> This file has been auto generated by EF Core Power Tools. </auto-generated>
#nullable disable
using Microsoft.Data.SqlClient;
...
```

fixes #2261 