### PR TITLE
fill DefaultValue for dacpac

### DIFF
--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -60,7 +60,7 @@ namespace UnitTests
         public void CanEnumerateSelectedQuirkObjects()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var tables = new List<string> { "[dbo].[FilteredIndexTable]", "[dbo].[DefaultComputedValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -82,7 +82,7 @@ namespace UnitTests
         public void CanEnumerateSelectedComputed()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var tables = new List<string> { "[dbo].[DefaultComputedValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -100,7 +100,7 @@ namespace UnitTests
         public void CanEnumerateTypeAlias()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var tables = new List<string> { "[dbo].[TypeAlias]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -120,7 +120,7 @@ namespace UnitTests
         public void CanHandleDefaultValues()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var tables = new List<string> { "[dbo].[DefaultValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -137,7 +137,7 @@ namespace UnitTests
         public void CanBuildAW2014()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -151,7 +151,7 @@ namespace UnitTests
         public void Issue208ComputedConstraint()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -165,7 +165,7 @@ namespace UnitTests
         public void Issue210ComputedConstraintIsFK()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -178,7 +178,7 @@ namespace UnitTests
         [Test]
         public void Issue1262_ConsiderSchemaArgument()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>() { "mat" });
 
             // Act
@@ -192,7 +192,7 @@ namespace UnitTests
         [Test]
         public void Issue1262_BehaviourWithoutSchemaArgument()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -208,7 +208,7 @@ namespace UnitTests
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Test")]
         public void Temporal_Support()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act

--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -60,7 +60,7 @@ namespace UnitTests
         public void CanEnumerateSelectedQuirkObjects()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var tables = new List<string> { "[dbo].[FilteredIndexTable]", "[dbo].[DefaultComputedValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -82,7 +82,7 @@ namespace UnitTests
         public void CanEnumerateSelectedComputed()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var tables = new List<string> { "[dbo].[DefaultComputedValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -100,7 +100,7 @@ namespace UnitTests
         public void CanEnumerateTypeAlias()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var tables = new List<string> { "[dbo].[TypeAlias]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -120,7 +120,7 @@ namespace UnitTests
         public void CanHandleDefaultValues()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var tables = new List<string> { "[dbo].[DefaultValues]" };
             var options = new DatabaseModelFactoryOptions(tables, new List<string>());
 
@@ -137,7 +137,7 @@ namespace UnitTests
         public void CanBuildAW2014()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -151,7 +151,7 @@ namespace UnitTests
         public void Issue208ComputedConstraint()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -165,7 +165,7 @@ namespace UnitTests
         public void Issue210ComputedConstraintIsFK()
         {
             // Arrange
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -178,7 +178,7 @@ namespace UnitTests
         [Test]
         public void Issue1262_ConsiderSchemaArgument()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>() { "mat" });
 
             // Act
@@ -192,7 +192,7 @@ namespace UnitTests
         [Test]
         public void Issue1262_BehaviourWithoutSchemaArgument()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act
@@ -208,7 +208,7 @@ namespace UnitTests
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Test")]
         public void Temporal_Support()
         {
-            var factory = new SqlServerDacpacDatabaseModelFactory(null);
+            var factory = new SqlServerDacpacDatabaseModelFactory(null, null);
             var options = new DatabaseModelFactoryOptions(null, new List<string>());
 
             // Act

--- a/src/Core/RevEng.Core.60/ServiceProviderBuilder.cs
+++ b/src/Core/RevEng.Core.60/ServiceProviderBuilder.cs
@@ -193,10 +193,12 @@ namespace RevEng.Core
             if (options.DatabaseType == DatabaseType.SQLServerDacpac)
             {
                 serviceCollection.AddSingleton<IDatabaseModelFactory, SqlServerDacpacDatabaseModelFactory>(
-                   provider => new SqlServerDacpacDatabaseModelFactory(new SqlServerDacpacDatabaseModelFactoryOptions
+                   serviceProvider => new SqlServerDacpacDatabaseModelFactory(
+                       new SqlServerDacpacDatabaseModelFactoryOptions
                    {
                        MergeDacpacs = options.MergeDacpacs,
-                   }));
+                   },
+                       serviceProvider.GetService<IRelationalTypeMappingSource>()));
 
                 serviceCollection.AddSqlServerDacpacStoredProcedureDesignTimeServices(new SqlServerDacpacDatabaseModelFactoryOptions
                 {

--- a/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac.csproj
+++ b/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>  
 
   <PropertyGroup>
-    <DefineConstants>TRACE;CORE70</DefineConstants>
+    <DefineConstants>TRACE;CORE70;CORE80</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In ef8 there is DefaultValue property in addition to DefaultValueSql. EF scaffolder looks at this property and if it's not-empty for 
a bool type, the result field will be generated as non-nullable bool. Since it's not filling now, it is always generated as bool?, which is different from what is generated directly from the database.

I've taken TryParseClrDefault implementation from efcore repository
https://github.com/dotnet/efcore/blob/017fb22e4b63003dc650905ea066b992895dc54d/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs#L843
https://github.com/dotnet/efcore/blob/017fb22e4b63003dc650905ea066b992895dc54d/src/Shared/SharedTypeExtensions.cs#L77