### PR TITLE
Implements #2518 to allow for excluding specific indexes during scaffolding

### DIFF
--- a/samples/efcpt-schema.json
+++ b/samples/efcpt-schema.json
@@ -61,6 +61,25 @@
                                 "Email"
                             ]
                         ]
+                    },
+                    "excludedIndexes": {
+                        "type": "array",
+                        "default": [],
+                        "title": "Indexes to Exclude from code generation",
+                        "items": {
+                            "type": "string",
+                            "title": "Index",
+                            "examples": [
+                                "UX_Parent_ChildId_TopLevel",
+                                "IX_WidgetId"
+                            ]
+                        },
+                        "examples": [
+                            [
+                                "UX_Parent_ChildId_TopLevel",
+                                "IX_WidgetId"
+                            ]
+                        ]
                     }
                 },
                 "examples": [{

--- a/src/Core/RevEng.Core.60/ServiceProviderBuilder.cs
+++ b/src/Core/RevEng.Core.60/ServiceProviderBuilder.cs
@@ -192,6 +192,7 @@ namespace RevEng.Core
 
             if (options.DatabaseType == DatabaseType.SQLServer)
             {
+                serviceCollection.AddSingleton(options);
                 serviceCollection.AddSingleton<IDatabaseModelFactory, PatchedSqlServerDatabaseModelFactory>();
                 serviceCollection.AddSqlServerStoredProcedureDesignTimeServices();
                 serviceCollection.AddSqlServerFunctionDesignTimeServices();

--- a/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
+++ b/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
@@ -312,7 +312,7 @@ namespace RevEng.Common.Cli
 
             var serializationTableModels = entities.Where<T>(entity => ExclusionFilter(entity, excludeAll, filters)
                 && !string.IsNullOrEmpty(entity.Name))
-                .Select(entity => new SerializationTableModel(entity.Name, objectType, entity.ExcludedColumns));
+                .Select(entity => new SerializationTableModel(entity.Name, objectType, entity.ExcludedColumns, entity.ExcludedIndexes));
             addRange(serializationTableModels);
         }
 

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Function.cs
@@ -24,5 +24,8 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonIgnore]
         public List<string> ExcludedColumns { get; set; } = null;
+
+        [JsonIgnore]
+        public List<string> ExcludedIndexes { get; set; } = null;
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/IEntity.cs
@@ -12,5 +12,8 @@ public interface IEntity
 
 #pragma warning disable CA2227 // Collection properties should be read only
     List<string> ExcludedColumns { get; set; }
+
+    List<string> ExcludedIndexes { get; set; }
+
 #pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/StoredProcedure.cs
@@ -32,5 +32,8 @@ namespace RevEng.Common.Cli.Configuration
 
         [JsonIgnore]
         public List<string> ExcludedColumns { get; set; }
+
+        [JsonIgnore]
+        public List<string> ExcludedIndexes { get; set; } = null;
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/Table.cs
@@ -15,6 +15,11 @@ namespace RevEng.Common.Cli.Configuration
         [JsonPropertyName("excludedColumns")]
         public List<string> ExcludedColumns { get; set; } = null;
 
+        [JsonPropertyOrder(20)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonPropertyName("excludedIndexes")]
+        public List<string> ExcludedIndexes { get; set; } = null;
+
         [JsonPropertyOrder(30)]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonPropertyName("exclusionWildcard")]

--- a/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/View.cs
@@ -24,5 +24,8 @@ namespace RevEng.Common.Cli.Configuration
         [JsonPropertyName("name")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Name { get; set; }
+
+        [JsonIgnore]
+        public List<string> ExcludedIndexes { get; set; } = null;
     }
 }

--- a/src/GUI/RevEng.Shared/SerializationTableModel.cs
+++ b/src/GUI/RevEng.Shared/SerializationTableModel.cs
@@ -13,7 +13,8 @@ namespace RevEng.Common
         public SerializationTableModel(
             string name,
             ObjectType objectType,
-            IList<string> excludedColumns)
+            IList<string> excludedColumns,
+            IList<string> excludedIndexes)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -23,6 +24,7 @@ namespace RevEng.Common
             Name = name;
             ExcludedColumns = excludedColumns?.Count > 0 ? excludedColumns : null;
             ObjectType = objectType;
+            ExcludedIndexes = excludedIndexes?.Count > 0 ? excludedIndexes : null;
         }
 
         /// <summary>
@@ -42,6 +44,12 @@ namespace RevEng.Common
         /// </summary>
         [DataMember(EmitDefaultValue = false, IsRequired = false)]
         public IEnumerable<string> ExcludedColumns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the indexes excluded from reverse engineering.
+        /// </summary>
+        [DataMember(EmitDefaultValue = false, IsRequired = false)]
+        public IEnumerable<string> ExcludedIndexes { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to exclude table from default result set discovery.

--- a/src/GUI/Shared/Handlers/ReverseEngineer/EfRevEngLauncher.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/EfRevEngLauncher.cs
@@ -68,7 +68,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
             if (!databaseObjects.Exists(t => t.ObjectType == ObjectType.Table))
             {
                 // No tables selected, so add a dummy table in order to generate an empty DbContext
-                databaseObjects.Add(new SerializationTableModel($"Dummy_{new Guid(GuidList.guidDbContextPackagePkgString)}", ObjectType.Table, null));
+                databaseObjects.Add(new SerializationTableModel($"Dummy_{new Guid(GuidList.guidDbContextPackagePkgString)}", ObjectType.Table, null, null));
             }
 
             var commandOptions = new ReverseEngineerCommandOptions

--- a/src/GUI/Shared/ViewModels/ObjectTreeViewModel.cs
+++ b/src/GUI/Shared/ViewModels/ObjectTreeViewModel.cs
@@ -81,7 +81,7 @@ namespace EFCorePowerTools.ViewModels
         {
             return Objects
                 .Where(c => c.IsSelected.Value)
-                .Select(m => new SerializationTableModel(m.ModelDisplayName, m.ObjectType, m.Columns.Where(c => !c.IsSelected.Value).Select(c => c.Name).ToList()));
+                .Select(m => new SerializationTableModel(m.ModelDisplayName, m.ObjectType, m.Columns.Where(c => !c.IsSelected.Value).Select(c => c.Name).ToList(), null));
         }
 
         public IEnumerable<Schema> GetRenamedObjects()

--- a/src/GUI/UnitTests/ReverseEngineerHelperTest.cs
+++ b/src/GUI/UnitTests/ReverseEngineerHelperTest.cs
@@ -17,10 +17,10 @@ namespace UnitTests
             // Arrange
             var tables = new List<SerializationTableModel>
             {
-                new SerializationTableModel("dbo.table", ObjectType.Table, null),
-                new SerializationTableModel("dbo.table.crazy", ObjectType.Table, null),
-                new SerializationTableModel("[dbo].[table]", ObjectType.Table, null),
-                new SerializationTableModel("[dbo].[table.mad]", ObjectType.Table, null),
+                new SerializationTableModel("dbo.table", ObjectType.Table, null, null),
+                new SerializationTableModel("dbo.table.crazy", ObjectType.Table, null, null),
+                new SerializationTableModel("[dbo].[table]", ObjectType.Table, null, null),
+                new SerializationTableModel("[dbo].[table.mad]", ObjectType.Table, null, null),
             };
 
             // Act
@@ -40,11 +40,11 @@ namespace UnitTests
             // Arrange
             var tables = new List<SerializationTableModel>
             {
-                new SerializationTableModel("dbo.table", ObjectType.Table, null),
-                new SerializationTableModel("dbo.table.crazy", ObjectType.Table, null),
-                new SerializationTableModel("[dbo].[table]", ObjectType.Table, null),
-                new SerializationTableModel("[dbo].[table.mad]", ObjectType.Table, null),
-                new SerializationTableModel("table", ObjectType.Table, null),
+                new SerializationTableModel("dbo.table", ObjectType.Table, null, null),
+                new SerializationTableModel("dbo.table.crazy", ObjectType.Table, null, null),
+                new SerializationTableModel("[dbo].[table]", ObjectType.Table, null, null),
+                new SerializationTableModel("[dbo].[table.mad]", ObjectType.Table, null, null),
+                new SerializationTableModel("table", ObjectType.Table, null, null),
             };
 
             // Act

--- a/src/GUI/UnitTests/ViewModels/ObjectTreeViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/ObjectTreeViewModelTests.cs
@@ -489,11 +489,11 @@ namespace UnitTests.ViewModels
         {
             var r = new SerializationTableModel[5];
 
-            r[0] = new SerializationTableModel("[dbo].[Atlas]", ObjectType.Table, new[] { "column1" });
-            r[1] = new SerializationTableModel("[unit].[test]", ObjectType.Table, new string[0]);
-            r[2] = new SerializationTableModel("[unit].[foo]", ObjectType.Table, new string[0]);
-            r[3] = new SerializationTableModel("[views].[view1]", ObjectType.View, new string[0]);
-            r[4] = new SerializationTableModel("[stored].[procedure2]", ObjectType.Procedure, new string[0]);
+            r[0] = new SerializationTableModel("[dbo].[Atlas]", ObjectType.Table, new[] { "column1" }, null);
+            r[1] = new SerializationTableModel("[unit].[test]", ObjectType.Table, new string[0], null);
+            r[2] = new SerializationTableModel("[unit].[foo]", ObjectType.Table, new string[0], null);
+            r[3] = new SerializationTableModel("[views].[view1]", ObjectType.View, new string[0], null);
+            r[4] = new SerializationTableModel("[stored].[procedure2]", ObjectType.Procedure, new string[0], null);
             return r;
         }
 

--- a/src/GUI/UnitTests/ViewModels/PickTablesViewModelTests.cs
+++ b/src/GUI/UnitTests/ViewModels/PickTablesViewModelTests.cs
@@ -249,7 +249,7 @@ namespace UnitTests.ViewModels
             {
                 mock.Setup(c => c.GetSelectedObjects()).Returns(() => new List<SerializationTableModel>()
                 {
-                    new SerializationTableModel("obj1", ObjectType.Table, new string[0]),
+                    new SerializationTableModel("obj1", ObjectType.Table, new string[0], null),
                 });
             }
 


### PR DESCRIPTION
Handles #2518.   This works around https://github.com/dotnet/efcore/issues/11298.

Example:

Before:

```json
{
  "name": "[dbo].[Widget]",
  "exclude": false
},
```

```csharp

 public void Configure(EntityTypeBuilder<Widget> entity)
  {
      entity.ToTable("Widget", tb =>
          {
              tb.HasTrigger("Widget_Insert");
              tb.HasTrigger("Widget_Update");
          });

      entity.HasIndex(e => new { e.CompanyId, e.IsDeleted, e.WidgetName }, "IX_Widget_CompanyIdIsDeletedWidgetName");

      entity.HasIndex(e => e.CompanyId, "UX_Widget_CompanyId_TopLevelWidget")
          .IsUnique()
          .HasFilter("([ParentWidgetId]=(0) AND [IsDeleted]=(0))");
}
```

After:

```json
{
  "name": "[dbo].[Folder]",
  "exclude": false,
  "excludedIndexes": [
    "UX_Folder_CompanyId_TopLevelFolder"
  ]
},
```

```csharp
 public void Configure(EntityTypeBuilder<Widget> entity)
{
    entity.ToTable("Widget", tb =>
        {
            tb.HasTrigger("Widget_Insert");
            tb.HasTrigger("Widget_Update");
        });
  
    entity.HasIndex(e => new { e.CompanyId, e.IsDeleted, e.WidgetName }, "IX_Widget_CompanyIdIsDeletedWidgetName");
}
```