### PR TITLE
Resolves #2545 - Adds a warning to the output if both 'code-generation/use-database-names' is set to true and 'efpt.renaming.json' exists.

### DIFF
--- a/src/Core/efcpt.8/HostedServices/ScaffoldHostedService.cs
+++ b/src/Core/efcpt.8/HostedServices/ScaffoldHostedService.cs
@@ -71,7 +71,7 @@ internal sealed class ScaffoldHostedService : HostedService
             scaffoldOptions.ConfigFile.FullName);
         DisplayService.MarkupLine();
 
-        if (commandOptions.UseDatabaseNames && commandOptions.CustomReplacers.Count > 0)
+        if (commandOptions.UseDatabaseNames && commandOptions.CustomReplacers?.Count > 0)
         {
             configWarnings.Add("'code-generation/use-database-names' has been set to true, but a 'efpt.renaming.json' file was also found.  'use-database-names' prevents 'efpt.renaming.json' from functioning.");
         }

--- a/src/Core/efcpt.8/HostedServices/ScaffoldHostedService.cs
+++ b/src/Core/efcpt.8/HostedServices/ScaffoldHostedService.cs
@@ -71,6 +71,10 @@ internal sealed class ScaffoldHostedService : HostedService
             scaffoldOptions.ConfigFile.FullName);
         DisplayService.MarkupLine();
 
+        if (commandOptions.UseDatabaseNames && commandOptions.CustomReplacers.Count > 0)
+        {
+            configWarnings.Add("'code-generation/use-database-names' has been set to true, but a 'efpt.renaming.json' file was also found.  'use-database-names' prevents 'efpt.renaming.json' from functioning.");
+        }
 #pragma warning disable S2589 // Boolean expressions should not be gratuitous
 #pragma warning disable S2583 // Conditionally executed code should be reachable
         if (commandOptions.UseT4 && Constants.Version > 6)


### PR DESCRIPTION
Resolves #2545 - Adds a warning to the output if both 'code-generation/use-database-names' is set to true and 'efpt.renaming.json' exists.

![image](https://github.com/user-attachments/assets/906b6330-bae4-489e-a82d-7e651f3a38f9)
