### PR TITLE
fix: handle separator under linux

### DIFF
--- a/src/Core/RevEng.Core.60/ReverseEngineerScaffolder.cs
+++ b/src/Core/RevEng.Core.60/ReverseEngineerScaffolder.cs
@@ -20,7 +20,7 @@ namespace RevEng.Core
 {
     public class ReverseEngineerScaffolder : IReverseEngineerScaffolder
     {
-        private static readonly string[] Separator = new string[] { "\r\n", "\r" };
+        private static readonly string[] Separator = new string[] { "\r\n", "\r", "\n" };
 
         private readonly IDatabaseModelFactory databaseModelFactory;
         private readonly IScaffoldingModelFactory factory;


### PR DESCRIPTION
EF Core Power Tools CLI 8.1.463 for EF Core 8

when configuration ` use-schema-namespaces-preview: true`

It throws under Linux but works in Windows
```
error: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at RevEng.Core.ReverseEngineerScaffolder.AppendSchemaNamespaceToModel(String entityTypeSchema, String code, IEnumerable`1 schemas) in D:\a\EFCorePowerTools\EFCorePowerTools\src\Core\RevEng.Core.60\ReverseEngineerScaffolder.cs:line 400
   at RevEng.Core.ReverseEngineerScaffolder.AppendSchemaFoldersAndNamespace(IModel databaseModel, ScaffoldedModel scaffoldedModel, Boolean useSchemaFolders, Boolean useSchemaNamespaces, IEnumerable`1 schemas) in
D:\a\EFCorePowerTools\EFCorePowerTools\src\Core\RevEng.Core.60\ReverseEngineerScaffolder.cs:line 335
   at RevEng.Core.ReverseEngineerScaffolder.ScaffoldModel(String connectionString, DatabaseModelFactoryOptions databaseOptions, ModelReverseEngineerOptions modelOptions, ModelCodeGenerationOptions codeOptions, Boolean removeNullableBoolDefaults, Boolean excludeNavigations,
Boolean dbContextOnly, Boolean entitiesOnly, Boolean useSchemaFolders, Boolean useSchemaNamespaces) in D:\a\EFCorePowerTools\EFCorePowerTools\src\Core\RevEng.Core.60\ReverseEngineerScaffolder.cs:line 508
   at RevEng.Core.ReverseEngineerScaffolder.GenerateDbContext(ReverseEngineerCommandOptions options, List`1 schemas, String outputContextDir, String modelNamespace, String contextNamespace, String projectPath, String outputPath) in
D:\a\EFCorePowerTools\EFCorePowerTools\src\Core\RevEng.Core.60\ReverseEngineerScaffolder.cs:line 94
   at RevEng.Core.ReverseEngineerRunner.GenerateFiles(ReverseEngineerCommandOptions options) in D:\a\EFCorePowerTools\EFCorePowerTools\src\Core\RevEng.Core.60\ReverseEngineerRunner.cs:line 86

```