### PR TITLE
Do not make DbContext name start with an upper case letter

### DIFF
--- a/src/Core/RevEng.Core.60/ReverseEngineerScaffolder.cs
+++ b/src/Core/RevEng.Core.60/ReverseEngineerScaffolder.cs
@@ -141,7 +141,7 @@ namespace RevEng.Core
                 var functionOptions = new ModuleScaffolderOptions
                 {
                     ContextDir = outputContextDir,
-                    ContextName = code.Identifier(options.ContextClassName, null, true),
+                    ContextName = code.Identifier(options.ContextClassName),
                     ContextNamespace = contextNamespace,
                     ModelNamespace = modelNamespace,
                     NullableReferences = options.UseNullableReferences,
@@ -204,7 +204,7 @@ namespace RevEng.Core
                 var procedureOptions = new ModuleScaffolderOptions
                 {
                     ContextDir = outputContextDir,
-                    ContextName = code.Identifier(options.ContextClassName, null, true),
+                    ContextName = code.Identifier(options.ContextClassName),
                     ContextNamespace = contextNamespace,
                     ModelNamespace = modelNamespace,
                     NullableReferences = options.UseNullableReferences,


### PR DESCRIPTION
Do not make DbContext name start with an upper case letter

fixes #2644