### PR TITLE
Adds new option to code-generation to allow for setting the classes that are generated for Stored Procedures and Functions as internal.

### DIFF
--- a/samples/efcpt-config.schema.json
+++ b/samples/efcpt-config.schema.json
@@ -272,6 +272,11 @@
           "type": "boolean",
           "title": "Use stored procedure, stored procedure result and function names from the database",
           "default": true
+        },
+        "use-internal-access-modifiers-for-sprocs-and-functions": {
+          "type": "boolean",
+          "title": "When generating the stored procedure classes and helpers, set them to internal instead of public.",
+          "default": false
         }
       }
     },

--- a/samples/efcpt-schema.json
+++ b/samples/efcpt-schema.json
@@ -461,6 +461,14 @@
                     "examples": [
                         false
                     ]
+                },
+                "use-internal-access-modifiers-for-sprocs-and-functions": {
+                  "type": "boolean",
+                  "title": "When generating the stored procedure classes and helpers, set them to internal instead of public.",
+                  "default": false,
+                  "examples": [
+                      true
+                  ]
                 }
             },
             "examples": [{

--- a/src/Core/RevEng.Core.80/DbContextExtensionsSqlQuery
+++ b/src/Core/RevEng.Core.80/DbContextExtensionsSqlQuery
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace #NAMESPACE#
 {
-    public static class DbContextExtensions
+    #ACCESSMODIFIER# static class DbContextExtensions
     {
         public static async Task<List<T>> SqlQueryAsync<T>(this DbContext db, string sql, object[] parameters = null, CancellationToken cancellationToken = default)
            where T : class
@@ -35,7 +35,7 @@ namespace #NAMESPACE#
         }
     }
 
-    public class OutputParameter<TValue>
+    #ACCESSMODIFIER# class OutputParameter<TValue>
     {
         private bool _valueSet = false;
 

--- a/src/Core/RevEng.Core.80/ReverseEngineerRunner.cs
+++ b/src/Core/RevEng.Core.80/ReverseEngineerRunner.cs
@@ -274,26 +274,36 @@ namespace RevEng.Core
         {
             if (options.UseDatabaseNames && options.CustomReplacers?.Count > 0)
             {
-                warnings.Add($"'use-database-names' / 'UseDatabaseNames' has been set to true, but a '{Constants.RenamingFileName}' file was also found. This prevents '{Constants.RenamingFileName}' from functioning.");
+                warnings.Add(
+                    $"'use-database-names' / 'UseDatabaseNames' has been set to true, but a '{Constants.RenamingFileName}' file was also found. This prevents '{Constants.RenamingFileName}' from functioning.");
             }
 
             if (options.UseT4 && options.UseT4Split)
             {
-                warnings.Add("Both UseT4 and UseT4Split are set to true.  Only one of these should be used, UseT4Split will be used.");
+                warnings.Add(
+                    "Both UseT4 and UseT4Split are set to true.  Only one of these should be used, UseT4Split will be used.");
                 options.UseT4 = false;
             }
 
             if (options.UseDbContextSplitting)
             {
-                warnings.Add("UseDbContextSplitting (preview) is obsolete, please switch to the T4 split DbContext template.");
+                warnings.Add(
+                    "UseDbContextSplitting (preview) is obsolete, please switch to the T4 split DbContext template.");
             }
 
             if (options.UseT4Split && options.UseDbContextSplitting)
             {
-                warnings.Add("Both UseDbContextSplitting (preview) and UseT4Split are set to true. Only one of these should be used, UseT4Split will be used.");
+                warnings.Add(
+                    "Both UseDbContextSplitting (preview) and UseT4Split are set to true. Only one of these should be used, UseT4Split will be used.");
                 options.UseDbContextSplitting = false;
             }
-        }
+
+            if (options.UseInternalAccessModifiersForSprocsAndFunctions && !(options.UseT4 || options.UseT4Split))
+            {
+                warnings.Add("UseInternalAccessModifiersForSprocsAndFunctions is set to true, but UseT4 or UseT4Split are not true.  This will result in conflicting access modifiers for the partial DBContext class.  This option is intended for when the T4 templates have been used and are setting the DBContext class to internal rather than public.  UseInternalAccessModifiersForSprocsAndFunctions will be reset to false to ensure a valid DBContext is generated.");
+                options.UseInternalAccessModifiersForSprocsAndFunctions = false;
+            }
+    }
 
         private static SavedModelFiles CreateCleanupPaths(SavedModelFiles procedurePaths, SavedModelFiles functionPaths, SavedModelFiles filePaths)
         {

--- a/src/Core/RevEng.Core.80/ReverseEngineerScaffolder.cs
+++ b/src/Core/RevEng.Core.80/ReverseEngineerScaffolder.cs
@@ -146,6 +146,7 @@ namespace RevEng.Core
                     UseAsyncCalls = options.UseAsyncCalls,
                     UsePascalIdentifiers = !options.UseDatabaseNamesForRoutines,
                     UseDecimalDataAnnotation = options.UseDecimalDataAnnotation,
+                    UseInternalAccessModifier = options.UseInternalAccessModifiersForSprocsAndFunctions,
                 };
 
                 var functionScaffoldedModel = functionModelScaffolder.ScaffoldModel(functionModel, functionOptions, schemas, ref errors);
@@ -156,7 +157,8 @@ namespace RevEng.Core
                         functionScaffoldedModel,
                         Path.GetFullPath(Path.Combine(options.ProjectPath, options.OutputPath ?? string.Empty)),
                         contextNamespace,
-                        options.UseAsyncCalls);
+                        options.UseAsyncCalls,
+                        functionOptions.UseInternalAccessModifier);
                 }
             }
 
@@ -212,6 +214,7 @@ namespace RevEng.Core
                     UseSchemaNamespaces = options.UseSchemaNamespaces,
                     UseDecimalDataAnnotation = options.UseDecimalDataAnnotation,
                     UsePascalIdentifiers = !options.UseDatabaseNamesForRoutines,
+                    UseInternalAccessModifier = options.UseInternalAccessModifiersForSprocsAndFunctions,
                 };
 
                 var procedureScaffoldedModel = procedureScaffolder.ScaffoldModel(procedureModel, procedureOptions, schemas, ref errors);
@@ -222,7 +225,8 @@ namespace RevEng.Core
                         procedureScaffoldedModel,
                         Path.GetFullPath(Path.Combine(options.ProjectPath, options.OutputPath ?? string.Empty)),
                         contextNamespace,
-                        options.UseAsyncCalls);
+                        options.UseAsyncCalls,
+                        procedureOptions.UseInternalAccessModifier);
                 }
             }
 

--- a/src/Core/RevEng.Core.80/Routines/Functions/FunctionScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Functions/FunctionScaffolder.cs
@@ -29,7 +29,7 @@ namespace RevEng.Core.Routines.Functions
 
         public string FileNameSuffix { get; set; }
 
-        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             return ScaffoldHelper.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls);
         }

--- a/src/Core/RevEng.Core.80/Routines/Functions/NotImplementedFunctionScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Functions/NotImplementedFunctionScaffolder.cs
@@ -8,7 +8,7 @@ namespace RevEng.Core.Routines.Functions
 {
     public class NotImplementedFunctionScaffolder : IFunctionScaffolder
     {
-        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             throw new NotSupportedException();
         }

--- a/src/Core/RevEng.Core.80/Routines/Functions/SqlServerFunctionScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Functions/SqlServerFunctionScaffolder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Design;
@@ -26,6 +25,8 @@ namespace RevEng.Core.Routines.Functions
             ArgumentNullException.ThrowIfNull(scaffolderOptions);
 
             ArgumentNullException.ThrowIfNull(model);
+
+            string accessModifier = scaffolderOptions.UseInternalAccessModifier ? "internal" : "public";
 
             Sb = new IndentedStringBuilder();
 
@@ -53,7 +54,7 @@ namespace RevEng.Core.Routines.Functions
 
             using (Sb.Indent())
             {
-                Sb.AppendLine($"public partial class {scaffolderOptions.ContextName}");
+                Sb.AppendLine($"{accessModifier} partial class {scaffolderOptions.ContextName}");
 
                 Sb.AppendLine("{");
 

--- a/src/Core/RevEng.Core.80/Routines/IRoutineScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/IRoutineScaffolder.cs
@@ -7,7 +7,7 @@ namespace RevEng.Core.Routines
 {
     public interface IRoutineScaffolder
     {
-        SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls);
+        SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier);
         ScaffoldedModel ScaffoldModel(RoutineModel model, ModuleScaffolderOptions scaffolderOptions, List<string> schemas, ref List<string> errors);
     }
 }

--- a/src/Core/RevEng.Core.80/Routines/Procedures/NotImplementedProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/NotImplementedProcedureScaffolder.cs
@@ -8,7 +8,7 @@ namespace RevEng.Core.Routines.Procedures
 {
     public class NotImplementedProcedureScaffolder : IProcedureScaffolder
     {
-        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             throw new NotSupportedException();
         }

--- a/src/Core/RevEng.Core.80/Routines/Procedures/PostgresStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/PostgresStoredProcedureScaffolder.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
@@ -24,17 +22,18 @@ namespace RevEng.Core.Routines.Procedures
             ProviderUsing = "using Npgsql";
         }
 
-        public new SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public new SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             ArgumentNullException.ThrowIfNull(scaffoldedModel);
 
-            var files = base.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls);
+            var files = base.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls, useInternalAccessModifier);
+            var accessModifier = useInternalAccessModifier ? "internal" : "public";
 
             var contextDir = Path.GetDirectoryName(Path.Combine(outputDir, scaffoldedModel.ContextFile.Path));
             var dbContextExtensionsText = ScaffoldHelper.GetDbContextExtensionsText(useAsyncCalls);
             var dbContextExtensionsName = useAsyncCalls ? "DbContextExtensions.cs" : "DbContextExtensions.Sync.cs";
             var dbContextExtensionsPath = Path.Combine(contextDir ?? string.Empty, dbContextExtensionsName);
-            File.WriteAllText(dbContextExtensionsPath, dbContextExtensionsText.Replace("#NAMESPACE#", nameSpaceValue, StringComparison.OrdinalIgnoreCase), Encoding.UTF8);
+            File.WriteAllText(dbContextExtensionsPath, dbContextExtensionsText.Replace("#NAMESPACE#", nameSpaceValue, StringComparison.OrdinalIgnoreCase).Replace("#ACCESSMODIFIER#", accessModifier, StringComparison.OrdinalIgnoreCase), Encoding.UTF8);
             files.AdditionalFiles.Add(dbContextExtensionsPath);
 
             return files;

--- a/src/Core/RevEng.Core.80/Routines/Procedures/ProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/ProcedureScaffolder.cs
@@ -25,7 +25,6 @@ namespace RevEng.Core.Routines.Procedures
         protected ProcedureScaffolder([System.Diagnostics.CodeAnalysis.NotNull] ICSharpHelper code, IClrTypeMapper typeMapper)
         {
             ArgumentNullException.ThrowIfNull(code);
-
             Code = code;
             this.typeMapper = typeMapper;
             scaffolder = new Scaffolder(code, typeMapper);
@@ -35,7 +34,7 @@ namespace RevEng.Core.Routines.Procedures
 
         public string ProviderUsing { get; set; }
 
-        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             return ScaffoldHelper.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls);
         }
@@ -175,6 +174,7 @@ namespace RevEng.Core.Routines.Procedures
             ArgumentNullException.ThrowIfNull(scaffolderOptions);
 
             ArgumentNullException.ThrowIfNull(model);
+            string accessModifier = scaffolderOptions.UseInternalAccessModifier ? "internal" : "public";
 
             Sb = new IndentedStringBuilder();
 
@@ -194,7 +194,7 @@ namespace RevEng.Core.Routines.Procedures
 
             using (Sb.Indent())
             {
-                Sb.AppendLine($"public partial interface I{scaffolderOptions.ContextName}{FileNameSuffix}");
+                Sb.AppendLine($"{accessModifier} partial interface I{scaffolderOptions.ContextName}{FileNameSuffix}");
                 Sb.AppendLine("{");
                 using (Sb.Indent())
                 {
@@ -219,6 +219,8 @@ namespace RevEng.Core.Routines.Procedures
 
             ArgumentNullException.ThrowIfNull(model);
 
+            string accessModifier = scaffolderOptions.UseInternalAccessModifier ? "internal" : "public";
+
             Sb = new IndentedStringBuilder();
 
             Sb.AppendLine(PathHelper.Header);
@@ -237,7 +239,7 @@ namespace RevEng.Core.Routines.Procedures
 
             using (Sb.Indent())
             {
-                Sb.AppendLine($"public partial class {scaffolderOptions.ContextName}");
+                Sb.AppendLine($"{accessModifier} partial class {scaffolderOptions.ContextName}");
                 Sb.AppendLine("{");
                 using (Sb.Indent())
                 {
@@ -281,7 +283,7 @@ namespace RevEng.Core.Routines.Procedures
                 Sb.AppendLine("}");
                 Sb.AppendLine();
 
-                Sb.AppendLine($"public partial class {scaffolderOptions.ContextName}{FileNameSuffix} : I{scaffolderOptions.ContextName}{FileNameSuffix}");
+                Sb.AppendLine($"{accessModifier} partial class {scaffolderOptions.ContextName}{FileNameSuffix} : I{scaffolderOptions.ContextName}{FileNameSuffix}");
                 Sb.AppendLine("{");
 
                 using (Sb.Indent())

--- a/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -23,17 +23,18 @@ namespace RevEng.Core.Routines.Procedures
             ProviderUsing = "using Microsoft.Data.SqlClient";
         }
 
-        public new SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls)
+        public new SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, string nameSpaceValue, bool useAsyncCalls, bool useInternalAccessModifier)
         {
             ArgumentNullException.ThrowIfNull(scaffoldedModel);
 
-            var files = base.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls);
+            var files = base.Save(scaffoldedModel, outputDir, nameSpaceValue, useAsyncCalls, useInternalAccessModifier);
+            var accessModifier = useInternalAccessModifier ? "internal" : "public";
 
             var contextDir = Path.GetDirectoryName(Path.Combine(outputDir, scaffoldedModel.ContextFile.Path));
             var dbContextExtensionsText = ScaffoldHelper.GetDbContextExtensionsText(useAsyncCalls);
             var dbContextExtensionsName = useAsyncCalls ? "DbContextExtensions.cs" : "DbContextExtensions.Sync.cs";
             var dbContextExtensionsPath = Path.Combine(contextDir ?? string.Empty, dbContextExtensionsName);
-            File.WriteAllText(dbContextExtensionsPath, dbContextExtensionsText.Replace("#NAMESPACE#", nameSpaceValue, StringComparison.OrdinalIgnoreCase), Encoding.UTF8);
+            File.WriteAllText(dbContextExtensionsPath, dbContextExtensionsText.Replace("#NAMESPACE#", nameSpaceValue, StringComparison.OrdinalIgnoreCase).Replace("#ACCESSMODIFIER#", accessModifier, StringComparison.OrdinalIgnoreCase), Encoding.UTF8);
             files.AdditionalFiles.Add(dbContextExtensionsPath);
 
             return files;

--- a/src/Core/RevEng.Core.Abstractions/ModuleScaffolderOptions.cs
+++ b/src/Core/RevEng.Core.Abstractions/ModuleScaffolderOptions.cs
@@ -14,5 +14,6 @@ namespace RevEng.Core.Abstractions
         public virtual bool UseSchemaNamespaces { get; set; }
         public virtual bool UseDecimalDataAnnotation { get; set; }
         public virtual bool UsePascalIdentifiers { get; set; }
+        public virtual bool UseInternalAccessModifier { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
+++ b/src/GUI/RevEng.Shared/Cli/CliConfigMapper.cs
@@ -96,6 +96,7 @@ namespace RevEng.Common.Cli
                 UseDecimalDataAnnotation = config.CodeGeneration.UseDecimalDataAnnotation,
                 UsePrefixNavigationNaming = config.CodeGeneration.UsePrefixNavigationNaming,
                 UseDatabaseNamesForRoutines = config.CodeGeneration.UseDatabaseNamesForRoutines,
+                UseInternalAccessModifiersForSprocsAndFunctions = config.CodeGeneration.UseInternalAccessModifiersForSprocsAndFunctions,
 
                 // Not supported:
                 UseHandleBars = false,
@@ -184,6 +185,7 @@ namespace RevEng.Common.Cli
                 ProjectRootNamespace = names.RootNamespace,
                 UseDecimalDataAnnotationForSprocResult = config.CodeGeneration.UseDecimalDataAnnotation,
                 UsePrefixNavigationNaming = config.CodeGeneration.UsePrefixNavigationNaming,
+                UseDatabaseNamesForRoutines = config.CodeGeneration.UseDatabaseNamesForRoutines,
 
                 // HandleBars templates are not supported:
                 UseHandleBars = false,

--- a/src/GUI/RevEng.Shared/Cli/Configuration/CodeGeneration.cs
+++ b/src/GUI/RevEng.Shared/Cli/Configuration/CodeGeneration.cs
@@ -93,5 +93,9 @@ namespace RevEng.Common.Cli.Configuration
         [JsonPropertyOrder(210)]
         [JsonPropertyName("use-t4-split")]
         public bool UseT4Split { get; set; }
+
+        [JsonPropertyOrder(220)]
+        [JsonPropertyName("use-internal-access-modifiers-for-sprocs-and-functions")]
+        public bool UseInternalAccessModifiersForSprocsAndFunctions { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
+++ b/src/GUI/RevEng.Shared/ReverseEngineerCommandOptions.cs
@@ -62,5 +62,6 @@ namespace RevEng.Common
         public bool UseDateOnlyTimeOnly { get; set; }
         public bool UsePrefixNavigationNaming { get; set; }
         public bool UseDatabaseNamesForRoutines { get; set; }
+        public bool UseInternalAccessModifiersForSprocsAndFunctions { get; set; }
     }
 }

--- a/src/GUI/RevEng.Shared/ReverseEngineerOptions.cs
+++ b/src/GUI/RevEng.Shared/ReverseEngineerOptions.cs
@@ -64,5 +64,6 @@ namespace RevEng.Common
         public bool UsePrefixNavigationNaming { get; set; }
         public bool UseAsyncStoredProcedureCalls { get; set; } = true;
         public bool UseDatabaseNamesForRoutines { get; set; } = true;
+        public bool UseInternalAccessModifiersForSprocsAndFunctions { get; set; }
     }
 }


### PR DESCRIPTION
Resolves #2741.

This PR adds a new configuration under code generation called `use-internal-access-modifiers-for-sprocs-and-functions`.  This setting will cause the generated classes for Functions and Stored Procedures to be `internal` rather than `public`.  This is for scenarios where T4 Templates are in use and consumers want to generate their `DBContext` and configurations as `internal` rather than `public` (often used in library style implementations where it's not desirable to expose the Data layer to consumers of a library).

A warning will be printed if `use-internal-access-modifiers-for-sprocs-and-functions` is set to true and `use-t4` or `use-t4-split` is not set. In this scenario, the `use-internal-access-modifiers-for-sprocs-and-functions` will be reset to false for the run in order to ensure a valid DBContext is generated.

The wiki docs will need to be updated with this information.

Eventually I could see this morphing to instead be a setting that could set the public/internal modifier for non-T4 scenarios as well, but that's way outside the scope of this work as it would require additional work in the stock DBContext generation.