### PR TITLE
Multiple configurations and connection changes fix

### DIFF
--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
@@ -146,8 +146,6 @@ namespace EFCorePowerTools
 
                 if (oleMenuCommandService != null)
                 {
-                    // temporary disabled until the wizard is ready
-
                     oleMenuCommandService.AddCommand(new OleMenuCommand(
                         OnProjectContextMenuInvokeHandler,
                         null,

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.cs
@@ -148,13 +148,13 @@ namespace EFCorePowerTools
                 {
                     // temporary disabled until the wizard is ready
 
-                    ////oleMenuCommandService.AddCommand(new OleMenuCommand(
-                    ////    OnProjectContextMenuInvokeHandler,
-                    ////    null,
-                    ////    OnProjectMenuBeforeQueryStatus,
-                    ////    new CommandID(
-                    ////        GuidList.GuidDbContextPackageCmdSet,
-                    ////        (int)PkgCmdIDList.cmdidWizardPoc)));
+                    oleMenuCommandService.AddCommand(new OleMenuCommand(
+                        OnProjectContextMenuInvokeHandler,
+                        null,
+                        OnProjectMenuBeforeQueryStatus,
+                        new CommandID(
+                            GuidList.GuidDbContextPackageCmdSet,
+                            (int)PkgCmdIDList.cmdidWizardPoc)));
 
                     oleMenuCommandService.AddCommand(new OleMenuCommand(
                         OnProjectContextMenuInvokeHandler,

--- a/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
+++ b/src/GUI/EFCorePowerTools/EFCorePowerToolsPackage.vsct
@@ -84,7 +84,7 @@
     </Menus>
 
     <Buttons>
-      <!--<Button guid="guidDbContextPackageCmdSet" id="cmdidWizardPoc" priority="0x0100" type="Button">
+      <Button guid="guidDbContextPackageCmdSet" id="cmdidWizardPoc" priority="0x0100" type="Button">
         <Parent guid="guidDbContextPackageCmdSet" id="cmdidEdmProjectMenuItemsGroup" />
         <Icon guid="ImageCatalogGuid" id="DatabaseConfigurationFile" />
         <CommandFlag>IconIsMoniker</CommandFlag>
@@ -93,7 +93,7 @@
         <Strings>
           <ButtonText>Reverse Engineer Wizard (preview)</ButtonText>
         </Strings>
-      </Button>-->
+      </Button>
 
       <Button guid="guidDbContextPackageCmdSet" id="cmdidReverseEngineerCodeFirst" priority="0x0101" type="Button">
         <Parent guid="guidDbContextPackageCmdSet" id="cmdidEdmProjectMenuItemsGroup" />

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
@@ -51,7 +51,6 @@ namespace EFCorePowerTools.Wizard
                     }
                 }
 
-                // viewModel.SelectedDatabaseConnection = viewModel.DatabaseConnections.FirstOrDefault();
                 wizardViewModel.RemoveDatabaseConnectionCommand.RaiseCanExecuteChanged();
             };
             addDefinitions = models =>
@@ -146,18 +145,10 @@ namespace EFCorePowerTools.Wizard
         public void NextButton_Click(object sender, RoutedEventArgs e)
 #pragma warning restore SA1202 // Elements should be ordered by access
         {
-            // Go to next wizard page
-            // if (wizardViewModel.IsPage1Initialized)
-            // {
-            //    NavigationService.GoForward();
-            // }
-            // else
-            {
-                wizardViewModel.IsPage1Initialized = true;
-                var wizardPage2 = new Wiz2_PickTablesDialog((WizardDataViewModel)DataContext, wizardView);
-                wizardPage2.Return += WizardPage_Return;
-                NavigationService?.Navigate(wizardPage2);
-            }
+            wizardViewModel.IsPage1Initialized = true;
+            var wizardPage2 = new Wiz2_PickTablesDialog((WizardDataViewModel)DataContext, wizardView);
+            wizardPage2.Return += WizardPage_Return;
+            NavigationService?.Navigate(wizardPage2);
         }
 
         /// <summary>

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
@@ -51,7 +51,7 @@ namespace EFCorePowerTools.Wizard
                     }
                 }
 
-                viewModel.SelectedDatabaseConnection = viewModel.DatabaseConnections.FirstOrDefault();
+                // viewModel.SelectedDatabaseConnection = viewModel.DatabaseConnections.FirstOrDefault();
                 wizardViewModel.RemoveDatabaseConnectionCommand.RaiseCanExecuteChanged();
             };
             addDefinitions = models =>
@@ -147,11 +147,11 @@ namespace EFCorePowerTools.Wizard
 #pragma warning restore SA1202 // Elements should be ordered by access
         {
             // Go to next wizard page
-            if (wizardViewModel.IsPage1Initialized)
-            {
-                NavigationService.GoForward();
-            }
-            else
+            // if (wizardViewModel.IsPage1Initialized)
+            // {
+            //    NavigationService.GoForward();
+            // }
+            // else
             {
                 wizardViewModel.IsPage1Initialized = true;
                 var wizardPage2 = new Wiz2_PickTablesDialog((WizardDataViewModel)DataContext, wizardView);

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
@@ -57,6 +57,7 @@ namespace EFCorePowerTools.Wizard
                 IsPageLoaded = false;
                 isDataLoaded = false;
                 wea.Options.UiHint = viewModel.UiHint;
+                wea.UserOptions.UiHint = viewModel.UiHint;
                 wea.Options.ConnectionString = viewModel.SelectedDatabaseConnection.ConnectionString;
                 wea.Options.DatabaseType = viewModel.SelectedDatabaseConnection.DatabaseType;
                 wea.Options.ContextClassName = null;

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using EFCorePowerTools.Contracts.ViewModels;
 using EFCorePowerTools.Contracts.Views;
 using EFCorePowerTools.Contracts.Wizard;
+using EFCorePowerTools.Handlers.ReverseEngineer;
 using EFCorePowerTools.Locales;
 using EFCorePowerTools.Messages;
 using EFCorePowerTools.ViewModels;
@@ -50,10 +51,25 @@ namespace EFCorePowerTools.Wizard
             var viewModel = wizardViewModel;
             IsPageLoaded = viewModel.IsPage2Initialized;
             var isDataLoaded = wizardViewModel.ObjectTree.Types.Any();
+            var wea = viewModel.WizardEventArgs;
+            if (wea.Options.UiHint != viewModel.UiHint)
+            {
+                IsPageLoaded = false;
+                isDataLoaded = false;
+                wea.Options.UiHint = viewModel.UiHint;
+                wea.Options.ConnectionString = viewModel.SelectedDatabaseConnection.ConnectionString;
+                wea.Options.DatabaseType = viewModel.SelectedDatabaseConnection.DatabaseType;
+                wea.Options.ContextClassName = null;
+
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    var dbinfo = await RevEngWizardHandler.GetDatabaseInfoAsync(wea.Options);
+                    wea.DbInfo = dbinfo;
+                });
+            }
 
             if (!IsPageLoaded && !isDataLoaded)
             {
-                var wea = wizardViewModel.WizardEventArgs;
                 wea.PickTablesDialog = this;
 
                 ThreadHelper.JoinableTaskFactory.Run(async () =>

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz3_EfCoreModelDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz3_EfCoreModelDialog.cs
@@ -98,6 +98,16 @@ namespace EFCorePowerTools.Wizard
         private void GenerateFiles_Click(object sender, RoutedEventArgs e)
         {
             var wea = wizardViewModel.WizardEventArgs;
+
+            // Ensure that userOptions hint matches the options hint
+            if (wea.UserOptions == null)
+            {
+                wea.UserOptions = new ReverseEngineerUserOptions
+                {
+                    UiHint = wea.Options.UiHint,
+                };
+            }
+
             var project = wea.Project;
             var optionsPath = wea.OptionsPath;
             var options = wea.Options;

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -609,7 +609,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
             return await builder.GetTableDefinitionsAsync(codeGenerationMode);
         }
 
-        private static async Task<DatabaseConnectionModel> GetDatabaseInfoAsync(ReverseEngineerOptions options)
+        public static async Task<DatabaseConnectionModel> GetDatabaseInfoAsync(ReverseEngineerOptions options)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -1004,7 +1004,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 await project.AddExistingFilesAsync(new List<string> { optionsPath }.ToArray());
             }
 
-            if (renamingOptions.Item1 != null && !File.Exists(renamingOptions.Item2 + ".ignore") && renamingOptions.Item1.Count > 0)
+            if (renamingOptions?.Item1 != null && !File.Exists(renamingOptions.Item2 + ".ignore") && renamingOptions.Item1.Count > 0)
             {
                 if (File.Exists(renamingOptions.Item2) && File.GetAttributes(renamingOptions.Item2).HasFlag(FileAttributes.ReadOnly))
                 {

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -345,7 +345,12 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                             await VS.StatusBar.ShowMessageAsync(ReverseEngineerLocale.GettingReadyToConnect);
                         }
 
-                        dbInfo = await GetDatabaseInfoAsync(options);
+                        // If no connection string is set then there is no need to get database info
+                        // as it will result in a dialog complaining about the provider
+                        if (options.ConnectionString != null)
+                        {
+                            dbInfo = await GetDatabaseInfoAsync(options);
+                        }
 
                         if (dbInfo == null || wizardArgs.PickServerDatabaseComplete)
                         {
@@ -353,6 +358,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                             // the wizard args state so that it can continue processing.  This handler is no
                             // longer driving the logic flow - the wizard pages are.
                             wizardArgs.DbInfo = dbInfo;
+                            wizardArgs.UserOptions = userOptions;
                             wizardArgs.Options = options;
                             wizardArgs.NamingOptionsAndPath = namingOptionsAndPath;
                             return;

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -603,7 +603,9 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
             return await builder.GetTableDefinitionsAsync(codeGenerationMode);
         }
 
+#pragma warning disable SA1202 // Elements should be ordered by access
         public static async Task<DatabaseConnectionModel> GetDatabaseInfoAsync(ReverseEngineerOptions options)
+#pragma warning restore SA1202 // Elements should be ordered by access
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -172,33 +172,21 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                     }
 
                     optionsPath = pickConfigResult.Payload.ConfigPath;
-
-                    // If not null then the wizard is invoking this process so we'll update state
-                    if (wizardArgs != null)
-                    {
-                        wizardArgs.Project = project;
-                        wizardArgs.OptionsPath = optionsPath;
-                        wizardArgs.OnlyGenerate = false;
-                        wizardArgs.FromSqlProject = false;
-                        wizardArgs.UiHint = uiHint;
-                    }
                 }
-                else
-                {
-                    if (wizardArgs != null)
-                    {
-                        wizardArgs.Project = project;
-                        wizardArgs.OptionsPath = optionsPath;
-                        wizardArgs.OnlyGenerate = false;
-                        wizardArgs.FromSqlProject = false;
-                        wizardArgs.UiHint = uiHint;
 
-                        wizardArgs.Configurations.Add(new ConfigModel
-                        {
-                            ConfigPath = optionsPath,
-                            ProjectPath = projectPath,
-                        });
-                    }
+                if (wizardArgs != null)
+                {
+                    wizardArgs.Project = project;
+                    wizardArgs.OptionsPath = optionsPath;
+                    wizardArgs.OnlyGenerate = false;
+                    wizardArgs.FromSqlProject = false;
+                    wizardArgs.UiHint = uiHint;
+
+                    wizardArgs.Configurations.Add(new ConfigModel
+                    {
+                        ConfigPath = optionsPath,
+                        ProjectPath = projectPath,
+                    });
                 }
 
                 await ReverseEngineerCodeFirstAsync(project, optionsPath, false, false, uiHint, wizardArgs);

--- a/src/GUI/Shared/ViewModels/WizardDataViewModel.cs
+++ b/src/GUI/Shared/ViewModels/WizardDataViewModel.cs
@@ -49,8 +49,10 @@ namespace EFCorePowerTools.ViewModels
             AddDatabaseDefinitionCommand = new RelayCommand(AddDatabaseDefinition_Executed);
             RemoveDatabaseConnectionCommand = new RelayCommand(RemoveDatabaseConnection_Executed, RemoveDatabaseConnection_CanExecute);
             FilterSchemasCommand = new RelayCommand(FilterSchemas_Executed, FilterSchemas_CanExecute);
-            CodeGenerationModeList = [];
-            DatabaseConnections = [];
+
+            CodeGenerationModeList = new ObservableCollection<CodeGenerationItem>();
+
+            DatabaseConnections = new ObservableCollection<DatabaseConnectionModel>();
             Schemas = new List<SchemaInfo>();
             DatabaseConnections.CollectionChanged += (sender, args) => RaisePropertyChanged(nameof(DatabaseConnections));
 
@@ -136,8 +138,8 @@ namespace EFCorePowerTools.ViewModels
         public RelayCommand RemoveDatabaseConnectionCommand { get; set; }
         public RelayCommand FilterSchemasCommand { get; set; }
 
-        public ObservableCollection<DatabaseConnectionModel> DatabaseConnections { get; set; } = [];
-        public ObservableCollection<CodeGenerationItem> CodeGenerationModeList { get; set; } = [];
+        public ObservableCollection<DatabaseConnectionModel> DatabaseConnections { get; }
+        public ObservableCollection<CodeGenerationItem> CodeGenerationModeList { get; }
 
         public List<SchemaInfo> Schemas { get; set; } = [];
 
@@ -184,6 +186,7 @@ namespace EFCorePowerTools.ViewModels
 
                 selectedDatabaseConnection = value;
                 RaisePropertyChanged();
+                this.ObjectTree.Types.Clear();
             }
         }
 


### PR DESCRIPTION
I tested these updates with multiple configuration files and multiple connections.  I verified that changing connections work as expected.   Note that once a configuration is selected that it can be viewed on the first page tab, but cannot be changed [perhaps future update?]; the wizard has to be exited and different configuration selected.