### PR TITLE
Issue 2900 many to many t4 split fix

### DIFF
--- a/src/GUI/lib/T4_800_Split/EFCore/EntityTypeConfiguration.t4
+++ b/src/GUI/lib/T4_800_Split/EFCore/EntityTypeConfiguration.t4
@@ -23,6 +23,12 @@
         Warning("Your templates were created using an older version of Entity Framework. Additional features and bug fixes may be available. See https://aka.ms/efcore-docs-updating-templates for more information.");
     }
 
+    if (EntityType.IsSimpleManyToManyJoinEntityType())
+    {
+        // Don't scaffold these
+        return "";
+    }
+
     var services = (IServiceProvider)Host;
     var providerCode = services.GetRequiredService<IProviderConfigurationCodeGenerator>();
     var annotationCodeGenerator = services.GetRequiredService<IAnnotationCodeGenerator>();

--- a/src/GUI/lib/T4_900_Split/EFCore/EntityTypeConfiguration.t4
+++ b/src/GUI/lib/T4_900_Split/EFCore/EntityTypeConfiguration.t4
@@ -23,6 +23,12 @@
         Warning("Your templates were created using an older version of Entity Framework. Additional features and bug fixes may be available. See https://aka.ms/efcore-docs-updating-templates for more information.");
     }
 
+    if (EntityType.IsSimpleManyToManyJoinEntityType())
+    {
+        // Don't scaffold these
+        return "";
+    }
+
     var services = (IServiceProvider)Host;
     var providerCode = services.GetRequiredService<IProviderConfigurationCodeGenerator>();
     var annotationCodeGenerator = services.GetRequiredService<IAnnotationCodeGenerator>();


### PR DESCRIPTION
Resolves #2900 by adding the same check that is in EntityType.t4 to EntityTypeConfiguration.t4.  This prevents an extra Configuration file from being generated when it's a Simple Many-To-Many and ensures consistent behavior between the Split T4s and the DbContext Split approach in this regard.