### PR TITLE
fix: ask_a_question template options values

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_ask_a_question.yml
+++ b/.github/ISSUE_TEMPLATE/02_ask_a_question.yml
@@ -61,21 +61,21 @@ body:
       label: Do you use T4 templates?
       multiple: false
       options:
-        - No
-        - Yes
+        - "No"
+        - "Yes"
   - type: dropdown
     id: handlebars
     attributes:
       label: Do you use Handlebars templates?
       multiple: false
       options:
-        - No
-        - Yes
+        - "No"
+        - "Yes"
   - type: dropdown
     id: dacpac
     attributes:
       label:  Is a SQL Server .dacpac / Database project used?
       multiple: false
       options:
-        - No
-        - Yes
+        - "No"
+        - "Yes"


### PR DESCRIPTION
GitHub does not allow for options to be boolean values, instead they should be strings.

Fixing this so I can issue a question following the expected templating.