### PR TITLE
#2931 Next disabled until connect select

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "9.0.102",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.203",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/src/GUI/EFCorePowerTools/Wizard/Resources/Converter.xaml
+++ b/src/GUI/EFCorePowerTools/Wizard/Resources/Converter.xaml
@@ -1,8 +1,9 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converter="clr-namespace:EFCorePowerTools.Converter"
                     xmlns:locale="clr-namespace:EFCorePowerTools.Locales">
 
+    <converter:BoolNullConverter x:Key="BoolNullConverter"/>
     <converter:BoolInvertConverter x:Key="BoolInvertConverter" />
     <converter:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     <converter:CollectionCountToVisibilityConverter x:Key="CollectionCountToVisibilityConverter" />

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.cs
@@ -171,7 +171,6 @@ namespace EFCorePowerTools.Wizard
             Statusbar.Status.ShowStatus();
             wizardViewModel.SelectedConfiguration = config;
             wizardViewModel.OptionsPath = config.ConfigPath;
-            NextButton.IsEnabled = true;
 
             wizardViewModel.RemoveDatabaseConnectionCommand.RaiseCanExecuteChanged();
         }

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.xaml
@@ -183,21 +183,47 @@
                         <RowDefinition Height="10" />
                     </Grid.RowDefinitions>
 
-                    <Label Grid.Column="1" Grid.Row="1">Config File:</Label>
+                    <Label Grid.Column="1"
+                           FontWeight="bold"
+                           Grid.Row="1">Selected Configuration File:</Label>
 
-                    <ComboBox Grid.Column="2" Grid.Row="1"
+                    <!--<ComboBox Grid.Column="2" Grid.Row="1"
                       TabIndex="1"
                       ItemsSource="{Binding Configurations, Mode=OneWay}"
                       SelectedItem="{Binding SelectedConfiguration, Mode=TwoWay}"
-                      DisplayMemberPath="DisplayName"/>
+                      ToolTip="{Binding SelectedConfiguration.DisplayName}"
+                      IsEnabled="False"
+                      DisplayMemberPath="DisplayName"/>-->
+
+                    <TextBlock Grid.Row="2"
+                               Grid.Column="1"
+                               Grid.ColumnSpan="3"
+                               TextWrapping="Wrap"
+                               Margin="5,0,0,0"
+                               Text="{Binding SelectedConfiguration.DisplayName}"
+                               FontStyle="Italic"
+                     />
+
                 </Grid>
             </TabItem>
         </TabControl>
         <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationPrevious}" IsEnabled="False" />
-            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationNext}" x:Name="NextButton" IsEnabled="{Binding SelectedDatabaseConnection, Converter={StaticResource BoolNullConverter}}"  Click="NextButton_Click" />
-            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.Add}" ToolTip="{x:Static locale:ReverseEngineerLocale.AddSchemasToFilter}" Command="{Binding FilterSchemasCommand}"/>
-            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationCancel}" Click="CancelButton_Click" IsCancel="True"/>
+            <Button Style="{StaticResource NavButton}"
+                    Content="{x:Static locale:ReverseEngineerLocale.NavigationPrevious}"
+                    IsEnabled="False" />
+            <Button Style="{StaticResource NavButton}"
+                    Content="{x:Static locale:ReverseEngineerLocale.NavigationNext}"
+                    x:Name="NextButton"
+                    IsEnabled="{Binding SelectedDatabaseConnection, Converter={StaticResource BoolNullConverter}}"
+                    Click="NextButton_Click" />
+            <Button Style="{StaticResource NavButton}"
+                    Content="{x:Static locale:ReverseEngineerLocale.Add}"
+                    ToolTip="{x:Static locale:ReverseEngineerLocale.AddSchemasToFilter}"
+                    Command="{Binding FilterSchemasCommand}"/>
+            <Button Style="{StaticResource NavButton}"
+                    Content="{x:Static locale:ReverseEngineerLocale.NavigationCancel}"
+                    Click="CancelButton_Click"
+                    IsCancel="True"/>
         </StackPanel>
         <statusbar:StatusbarControl Grid.Row="2" x:Name="Statusbar"/>
     </Grid>

--- a/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.xaml
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz1_PickServerDatabaseDialog.xaml
@@ -1,4 +1,4 @@
-﻿<local:WizardResultPageFunction
+<local:WizardResultPageFunction
     x:Class="EFCorePowerTools.Wizard.Wiz1_PickServerDatabaseDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
@@ -23,6 +23,7 @@
             <ResourceDictionary>
                 <ResourceDictionary.MergedDictionaries>
                     <ResourceDictionary Source="Resources\Style.xaml"/>
+                    <ResourceDictionary Source="Resources\Converter.xaml"/>
                 </ResourceDictionary.MergedDictionaries>
             </ResourceDictionary>
         </Grid.Resources>
@@ -194,7 +195,7 @@
         </TabControl>
         <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationPrevious}" IsEnabled="False" />
-            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationNext}" x:Name="NextButton" IsEnabled="False" Click="NextButton_Click" />
+            <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationNext}" x:Name="NextButton" IsEnabled="{Binding SelectedDatabaseConnection, Converter={StaticResource BoolNullConverter}}"  Click="NextButton_Click" />
             <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.Add}" ToolTip="{x:Static locale:ReverseEngineerLocale.AddSchemasToFilter}" Command="{Binding FilterSchemasCommand}"/>
             <Button Style="{StaticResource NavButton}" Content="{x:Static locale:ReverseEngineerLocale.NavigationCancel}" Click="CancelButton_Click" IsCancel="True"/>
         </StackPanel>

--- a/src/GUI/Shared/Converter/BoolNullConverter.cs
+++ b/src/GUI/Shared/Converter/BoolNullConverter.cs
@@ -12,7 +12,7 @@ namespace EFCorePowerTools.Converter
             object parameter,
             CultureInfo culture)
         {
-            return value == null || string.IsNullOrEmpty($"{value}");
+            return value != null;
         }
 
         object IValueConverter.ConvertBack(
@@ -21,7 +21,7 @@ namespace EFCorePowerTools.Converter
             object parameter,
             CultureInfo culture)
         {
-            return value == null || string.IsNullOrEmpty($"{value}");
+            return value != null;
         }
     }
 }

--- a/src/GUI/Shared/Converter/BoolNullConverter.cs
+++ b/src/GUI/Shared/Converter/BoolNullConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EFCorePowerTools.Converter
+{
+    public class BoolNullConverter : IValueConverter
+    {
+        object IValueConverter.Convert(
+            object value,
+            Type targetType,
+            object parameter,
+            CultureInfo culture)
+        {
+            return value == null || string.IsNullOrEmpty($"{value}");
+        }
+
+        object IValueConverter.ConvertBack(
+            object value,
+            Type targetType,
+            object parameter,
+            CultureInfo culture)
+        {
+            return value == null || string.IsNullOrEmpty($"{value}");
+        }
+    }
+}

--- a/src/GUI/Shared/Shared.projitems
+++ b/src/GUI/Shared/Shared.projitems
@@ -55,6 +55,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\Views\PickTablesDialogResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\Wizard\IWizardView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Contracts\Wizard\IWizardViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converter\BoolNullConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converter\BoolInvertConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converter\BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converter\CollectionCountToEnabledConverter.cs" />


### PR DESCRIPTION
Added new BoolNullConverter so that it can control the Next Button IsEnabled value (only enabled if SelectedConnectionString is not null).  On the Config tab I made it more apparent that only the configuration path is displayed - removed combo and replaced with textbox.   