### PR TITLE
#3050 Resolved issue with ContextName not persisting on updates.

### DIFF
--- a/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz2_PickTablesDialog.cs
@@ -59,7 +59,6 @@ namespace EFCorePowerTools.Wizard
                 wea.UserOptions.UiHint = viewModel.UiHint;
                 wea.Options.ConnectionString = viewModel.SelectedDatabaseConnection.ConnectionString;
                 wea.Options.DatabaseType = viewModel.SelectedDatabaseConnection.DatabaseType;
-                wea.Options.ContextClassName = null;
                 wea.Options.Dacpac = viewModel.SelectedDatabaseConnection.FilePath;
 
                 ThreadHelper.JoinableTaskFactory.Run(async () =>


### PR DESCRIPTION
When updating Options from the view model selections, a null was being applied to the ContextClassName [probably a remnant of very early coding] which caused subsequent processing to regenerate the context name.   Tested with both new configuration files as well as updates to existing files, no issues noted; configured context name successfully persisted .