### PR TITLE
#3105 Resolved issue where EFPT hangs if Markdown extension is installed

### DIFF
--- a/src/GUI/EFCorePowerTools/Wizard/Wiz4_StatusDialog.xaml.cs
+++ b/src/GUI/EFCorePowerTools/Wizard/Wiz4_StatusDialog.xaml.cs
@@ -12,6 +12,7 @@ using EFCorePowerTools.Locales;
 using EFCorePowerTools.Messages;
 using EFCorePowerTools.ViewModels;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading; // Added for JoinableTaskFactory (kept for SwitchToMainThreadAsync)
 using RevEng.Common;
 
 namespace EFCorePowerTools.Wizard
@@ -80,76 +81,110 @@ namespace EFCorePowerTools.Wizard
                 wizardViewModel.Bll.GetModelOptionsPostDialog(options, project.Name, wea, wizardViewModel.Model);
                 var errorMessage = string.Empty;
 
-                // CHANGED: Replaced Run(...) (blocking UI thread) with RunAsync(...) (non-blocking).
-#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                // Replaced JoinableTaskFactory.RunAsync(...).FileAndForget with explicit Task method and robust exception handling.
+                _ = RunGenerationAsync();
+
+                async System.Threading.Tasks.Task RunGenerationAsync()
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                    // Show busy overlay
-                    busyOverlay.BusyMessage = "Generating files...";
-                    busyOverlay.IsBusy = true;
-
                     try
                     {
-                        await InvokeWithErrorHandlingAsync(async () =>
-                        {
-                            await wizardViewModel.Bll.SaveOptionsAsync(project, optionsPath, options, userOptions, new Tuple<List<Schema>, string>(options.CustomReplacers, namingOptionsAndPath.Item2));
-
-                            await RevEngWizardHandler.InstallNuGetPackagesAsync(project, onlyGenerate, options, forceEdit, wea);
-
-                            var neededPackages = await wea.Project.GetNeededPackagesAsync(wea.Options);
-                            var missingProviderPackage = neededPackages.Find(p => p.DatabaseTypes.Contains(options.DatabaseType) && p.IsMainProviderPackage && !p.Installed)?.PackageId;
-                            if (options.InstallNuGetPackage || options.SelectedToBeGenerated == 2)
-                            {
-                                missingProviderPackage = null;
-                            }
-
-                            wea.ReverseEngineerStatus = await wizardViewModel.Bll.GenerateFilesAsync(project, options, missingProviderPackage, onlyGenerate, neededPackages, true);
-
-                            var postRunFile = Path.Combine(Path.GetDirectoryName(optionsPath), "efpt.postrun.cmd");
-                            if (File.Exists(postRunFile))
-                            {
-                                Process.Start($"\"{postRunFile}\"");
-                            }
-
-                            return true;
-                        });
-
-                        if (string.IsNullOrEmpty(errorMessage))
-                        {
-                            Statusbar.Status.ShowStatus();
-                            wizardViewModel.GenerateStatus = wea.ReverseEngineerStatus;
-                        }
-                        else
-                        {
-                            wizardViewModel.GenerateStatus = $"❌ {errorMessage}";
-                        }
-
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                        var win = Window.GetWindow(this);
-                        if (win != null)
-                        {
-                            win.Activate();
-                            win.Focus();
-                        }
 
-                        if (FinishButton != null)
+                        // Show busy overlay
+                        busyOverlay.BusyMessage = "Generating files...";
+                        busyOverlay.IsBusy = true;
+
+                        try
                         {
+                            await InvokeWithErrorHandlingAsync(async () =>
+                            {
+                                await wizardViewModel.Bll.SaveOptionsAsync(
+                                    project,
+                                    optionsPath,
+                                    options,
+                                    userOptions,
+                                    new Tuple<List<Schema>, string>(options.CustomReplacers, namingOptionsAndPath.Item2));
+
+                                await RevEngWizardHandler.InstallNuGetPackagesAsync(project, onlyGenerate, options, forceEdit, wea);
+
+                                var neededPackages = await wea.Project.GetNeededPackagesAsync(wea.Options);
+                                var missingProviderPackage = neededPackages.Find(p => p.DatabaseTypes.Contains(options.DatabaseType) && p.IsMainProviderPackage && !p.Installed)?.PackageId;
+                                if (options.InstallNuGetPackage || options.SelectedToBeGenerated == 2)
+                                {
+                                    missingProviderPackage = null;
+                                }
+
+                                wea.ReverseEngineerStatus = await wizardViewModel.Bll.GenerateFilesAsync(
+                                    project,
+                                    options,
+                                    missingProviderPackage,
+                                    onlyGenerate,
+                                    neededPackages,
+                                    true);
+
+                                var postRunFile = Path.Combine(Path.GetDirectoryName(optionsPath), "efpt.postrun.cmd");
+                                if (File.Exists(postRunFile))
+                                {
+                                    Process.Start($"\"{postRunFile}\"");
+                                }
+
+                                return true;
+                            });
+
+                            if (string.IsNullOrEmpty(errorMessage))
+                            {
+                                Statusbar.Status.ShowStatus();
+                                wizardViewModel.GenerateStatus = wea.ReverseEngineerStatus;
+                            }
+                            else
+                            {
+                                wizardViewModel.GenerateStatus = $"❌ {errorMessage}";
+                            }
+
+                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                            var win = Window.GetWindow(this);
+                            if (win != null)
+                            {
+                                win.Activate();
+                                win.Focus();
+                            }
+
+                            if (FinishButton != null)
+                            {
+                                FinishButton.IsEnabled = true;
+                                FinishButton.IsDefault = true;
+                                FinishButton.Focus();
+                                Keyboard.Focus(FinishButton);
+                            }
+
+                            PreviousButton.IsEnabled = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            // Capture unexpected exceptions not handled by InvokeWithErrorHandlingAsync
+                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            wizardViewModel.GenerateStatus = $"❌ {ex.Message}";
+                            Statusbar.Status.ShowStatusError("Error occurred");
                             FinishButton.IsEnabled = true;
-                            FinishButton.IsDefault = true;
-                            FinishButton.Focus();
-                            Keyboard.Focus(FinishButton);
-                        }
+                            PreviousButton.IsEnabled = true;
 
-                        PreviousButton.IsEnabled = true;
+                            try
+                            {
+                                ActivityLog.TryLogError("EFCorePowerTools", ex.ToString());
+                            }
+                            catch
+                            {
+                                // Ignore logging failures
+                            }
+                        }
                     }
                     finally
                     {
+                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         busyOverlay.IsBusy = false;
                     }
-                }).FileAndForget("EFCorePowerTools/Wiz4_StatusDialog/Generation");
-#pragma warning restore VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
+                }
             }
         }
 

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -19,10 +19,8 @@ using EFCorePowerTools.Helpers;
 using EFCorePowerTools.Locales;
 using EFCorePowerTools.Wizard;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Data.Services;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Versioning;
 using RevEng.Common;
 
@@ -503,40 +501,33 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
             if ((options.SelectedToBeGenerated == 0 || options.SelectedToBeGenerated == 1)
                 && AdvancedOptions.Instance.OpenGeneratedDbContext && !onlyGenerate)
             {
-                var readmeName = "PowerToolsReadMe.md";
+                var readmeName = "PowerToolsReadMe.md"; // Align with non-wizard handler pattern
                 var template = File.ReadAllText(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), readmeName), Encoding.UTF8);
 
-                if (packages.Any())
-                {
-                    finalText = ReverseEngineerHelper.GetReadMeText(options, template, packages);
-                }
-                else
-                {
-                    finalText = ReverseEngineerHelper.GetReadMeText(options, template);
-                }
+                finalText = packages.Any()
+                    ? ReverseEngineerHelper.GetReadMeText(options, template, packages)
+                    : ReverseEngineerHelper.GetReadMeText(options, template);
 
                 readmePath = Path.Combine(Path.GetTempPath(), readmeName);
-
                 finalText = ReverseEngineerHelper.AddResultToFinalText(finalText, revEngResult);
-
                 File.WriteAllText(readmePath, finalText, Encoding.UTF8);
 
+                // Use same simple open pattern as ReverseEngineerHandler to avoid potential UI hang
                 if (revEngResult.HasIssues)
                 {
                     if (!string.IsNullOrEmpty(revEngResult.ContextFilePath))
                     {
-                        await OpenDocumentAsync(revEngResult.ContextFilePath, preview: false, isCalledByWizard);
+                        await VS.Documents.OpenAsync(revEngResult.ContextFilePath);
                     }
 
-                    await OpenDocumentAsync(readmePath, preview: true, isCalledByWizard);
+                    await VS.Documents.OpenInPreviewTabAsync(readmePath);
                 }
                 else
                 {
-                    await OpenDocumentAsync(readmePath, preview: true, isCalledByWizard);
-
+                    await VS.Documents.OpenInPreviewTabAsync(readmePath);
                     if (!string.IsNullOrEmpty(revEngResult.ContextFilePath))
                     {
-                        await OpenDocumentAsync(revEngResult.ContextFilePath, preview: false, isCalledByWizard);
+                        await VS.Documents.OpenAsync(revEngResult.ContextFilePath);
                     }
                 }
             }
@@ -825,7 +816,6 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 await VS.StatusBar.ClearAsync();
             }
 
-            // If the wizard is driving then it's implementation of the interface will be used.
             var ptd = wizardArgs?.PickTablesDialog ?? package.GetView<IPickTablesDialog>();
             ptd.AddTables(predefinedTables, namingOptionsAndPath.Item1)
                .PreselectTables(preselectedTables)
@@ -844,11 +834,8 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
         {
             var isInvokedByWizard = wizardArgs.PickTablesDialogComplete;
 
-            // If this is being invoked by wizard then get fresh list of selected files for processing
-            // (developer can select/deselect other objects).
             if (isInvokedByWizard)
             {
-                // If the wizard is driving then it's implementation of the interface will be used.
                 var ptd = wizardArgs.PickTablesDialog ?? package.GetView<IPickTablesDialog>();
                 var pickTablesResult = ptd.ShowAndAwaitUserResponse(true);
 
@@ -898,8 +885,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 T4TemplatePath = options.T4TemplatePath,
             };
 
-            // If the wizard is driving then it's implementation of the interface will be used.
-            var modelDialog = wizardArgs.ModelingOptionsDialog ?? package.GetView<IModelingOptionsDialog>();
+            var modelDialog = wizardArgs?.ModelingOptionsDialog ?? package.GetView<IModelingOptionsDialog>();
             modelDialog.ApplyPresets(presets);
 
             var allowedTemplates = reverseEngineerHelper.CalculateAllowedTemplates(options.CodeGenerationMode);
@@ -1028,7 +1014,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
 
                 File.WriteAllText(optionsPath, options.Write(), Encoding.UTF8);
 
-                await project.AddExistingFilesAsync(new List<string> { optionsPath }.ToArray());
+                await project.AddExistingFilesAsync(optionsPath);
             }
 
             if (renamingOptions?.Item1 != null && !File.Exists(renamingOptions.Item2 + ".ignore") && renamingOptions.Item1.Count > 0)
@@ -1040,44 +1026,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 }
 
                 File.WriteAllText(renamingOptions.Item2, CustomNameOptionsExtensions.Write(renamingOptions.Item1), Encoding.UTF8);
-                await project.AddExistingFilesAsync(new List<string> { renamingOptions.Item2 }.ToArray());
-            }
-        }
-
-        // Helper to open documents with consistent provisional/no-activate behavior when wizard is driving
-        private static async Task OpenDocumentAsync(string path, bool preview, bool isCalledByWizard)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                return;
-            }
-
-            if (isCalledByWizard)
-            {
-                using (new NewDocumentStateScope(
-                    __VSNEWDOCUMENTSTATE.NDS_NoActivate | __VSNEWDOCUMENTSTATE.NDS_Provisional,
-                    VSConstants.NewDocumentStateReason.Navigation))
-                {
-                    if (preview)
-                    {
-                        await VS.Documents.OpenInPreviewTabAsync(path);
-                    }
-                    else
-                    {
-                        await VS.Documents.OpenAsync(path);
-                    }
-                }
-            }
-            else
-            {
-                if (preview)
-                {
-                    await VS.Documents.OpenInPreviewTabAsync(path);
-                }
-                else
-                {
-                    await VS.Documents.OpenAsync(path);
-                }
+                await project.AddExistingFilesAsync(renamingOptions.Item2);
             }
         }
     }

--- a/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
+++ b/src/GUI/Shared/Handlers/ReverseEngineer/RevEngWizardHandler.cs
@@ -894,7 +894,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 new Contracts.ViewModels.TemplateTypeItem { Key = options.SelectedHandlebarsLanguage },
                 allowedTemplates);
 
-            if (!wizardArgs.IsInvokedByWizard)
+            if (wizardArgs != null && !wizardArgs.IsInvokedByWizard)
             {
                 await VS.StatusBar.ClearAsync();
             }
@@ -1014,7 +1014,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
 
                 File.WriteAllText(optionsPath, options.Write(), Encoding.UTF8);
 
-                await project.AddExistingFilesAsync(optionsPath);
+                await project.AddExistingFilesAsync(new List<string> { optionsPath }.ToArray());
             }
 
             if (renamingOptions?.Item1 != null && !File.Exists(renamingOptions.Item2 + ".ignore") && renamingOptions.Item1.Count > 0)
@@ -1026,7 +1026,7 @@ namespace EFCorePowerTools.Handlers.ReverseEngineer
                 }
 
                 File.WriteAllText(renamingOptions.Item2, CustomNameOptionsExtensions.Write(renamingOptions.Item1), Encoding.UTF8);
-                await project.AddExistingFilesAsync(renamingOptions.Item2);
+                await project.AddExistingFilesAsync(new List<string> { renamingOptions.Item2 }.ToArray());
             }
         }
     }


### PR DESCRIPTION
fixes #3105 

Mark down editor extension attempts to open UI thread while wizard is still mid-await on UI thread (reentrancy deadlock).   Evolution of code allowed me to utilize the more simplified approach [used by legacy editor] for handling the readme markdown file.

Was able to duplicate and resolve issue.