### PR TITLE
#3334 Update EFCorePowerTools.csproj to support ARM

### DIFF
--- a/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
+++ b/src/GUI/EFCorePowerTools/EFCorePowerTools.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
@@ -287,27 +287,7 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.17.0.146, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\lib\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="Exists('$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll')">
-      <HintPath>$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="!Exists('$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll') and Exists('$(DevEnvDir)VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll')">
-      <HintPath>$(DevEnvDir)VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="!Exists('$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(DevEnvDir)VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll') and Exists('$(ProgramFiles)\Microsoft Visual Studio\18\Community\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll')">
-      <HintPath>$(ProgramFiles)\Microsoft Visual Studio\18\Community\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="!Exists('$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(DevEnvDir)VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(ProgramFiles)\Microsoft Visual Studio\18\Community\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll') and Exists('$(ProgramFiles)\Microsoft Visual Studio\18\Insiders\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll')">
-      <HintPath>$(ProgramFiles)\Microsoft Visual Studio\18\Insiders\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" Condition="!Exists('$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(DevEnvDir)VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(ProgramFiles)\Microsoft Visual Studio\18\Community\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll') and !Exists('$(ProgramFiles)\Microsoft Visual Studio\18\Insiders\Common7\IDE\VSExtensions\Microsoft\AppModernizationForDotNet\Microsoft.VisualStudio.TemplateWizardInterface.dll')" />
+    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -735,6 +715,3 @@
     </ItemGroup>
   </Target>
 </Project>
-
-
-


### PR DESCRIPTION
Problem
GUI/EFCorePowerTools/EFCorePowerTools.csproj had a single direct reference to:
Microsoft.VisualStudio.TemplateWizardInterface, Version=17.0.0.0
This worked on GitHub Actions but failed on ARM-based VS2026 installs with missing TemplateWizard types (IWizard, WizardRunKind), depending on where MSBuild resolved the assembly from.

On ARM/VS2026, assembly resolution can differ from x64/GitHub layouts:
•	Some paths resolve to TemplateWizardInterface v18 (PublicAssemblies), which can introduce version mismatch issues.
•	The project needs v17-compatible resolution for current SDK/package graph.

Solution:  let Copilot resolve as build issues arise