### PR TITLE
chore: remove unused usings

### DIFF
--- a/test/ScaffoldingTester/ConsoleApp/Models/Album.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Album.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Artist.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Artist.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/ChinookContext.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/ChinookContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/AlbumConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/AlbumConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/ArtistConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/ArtistConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/CustomerConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/CustomerConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/EmployeeConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/EmployeeConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/GenreConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/GenreConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/InvoiceConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/InvoiceConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/InvoiceLineConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/InvoiceLineConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/MediaTypeConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/MediaTypeConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/PlaylistConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/PlaylistConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Configurations/TrackConfiguration.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Configurations/TrackConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ConsoleApp.Models.Configurations;

--- a/test/ScaffoldingTester/ConsoleApp/Models/Customer.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Customer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Genre.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Genre.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/InvoiceLine.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/InvoiceLine.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace ConsoleApp.Models;
+﻿namespace ConsoleApp.Models;
 
 public partial class InvoiceLine
 {

--- a/test/ScaffoldingTester/ConsoleApp/Models/MediaType.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/MediaType.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Playlist.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Playlist.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Models/Track.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Models/Track.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace ConsoleApp.Models;
 

--- a/test/ScaffoldingTester/ConsoleApp/Program.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Program.cs
@@ -1,7 +1,5 @@
 ﻿using ConsoleApp.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
-using System;
 using System.Linq;
 
 namespace ConsoleApp

--- a/test/ScaffoldingTester/PostgresTester/Models/NorthwindContext.custom.cs
+++ b/test/ScaffoldingTester/PostgresTester/Models/NorthwindContext.custom.cs
@@ -1,6 +1,4 @@
 ﻿#nullable enable
-using System;
-using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
 namespace PostgresTester.Models;

--- a/test/ScaffoldingTester/ScaffoldingTester5/Models/BoolNullableTest1.cs
+++ b/test/ScaffoldingTester/ScaffoldingTester5/Models/BoolNullableTest1.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace ScaffoldingTester.Models
+﻿namespace ScaffoldingTester.Models
 {
     public partial class BoolNullableTest1
     {

--- a/test/ScaffoldingTester/ScaffoldingTester5/Models/BoolNullableTestxx.cs
+++ b/test/ScaffoldingTester/ScaffoldingTester5/Models/BoolNullableTestxx.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace ScaffoldingTester.Models
+﻿namespace ScaffoldingTester.Models
 {
     public partial class BoolNullableTestxx
     {


### PR DESCRIPTION
Only touching test files. I used `dotnet format style`, a little trick to remove unused usings.
I did have to copy the /src/.editorconfig to /test/.editorconfig temporarily to get this to work.

Possibly .editorconfig should be moved to the repo root