### PR TITLE
fix(scaffoldingtester): await async console error write

### DIFF
--- a/test/ScaffoldingTester/ScaffoldingTester/Program.cs
+++ b/test/ScaffoldingTester/ScaffoldingTester/Program.cs
@@ -15,7 +15,7 @@ namespace ScaffoldingTester
                 var result = await db.GetProcedures().CustOrdersOrdersAsync("ALFKI");
                 if (result.Count != 6)
                 {
-                    Console.Error.WriteLine($"AssertEqual failed. Expected: \"6\". Actual: {result.Count}.");
+                    await Console.Error.WriteLineAsync($"AssertEqual failed. Expected: \"6\". Actual: {result.Count}.");
                 }
             }
         }


### PR DESCRIPTION
  ScaffoldingTester/Program.cs:18 is a real behavior-preserving analyzer
  fix. Main is already async, and Console.Error.WriteLine(...) triggered
  CA1849 because it does synchronous I/O inside an async flow. Changing
  it to await Console.Error.WriteLineAsync(...) resolves that warning
  without changing the intended output.