### PR TITLE
style(consoleapp): remove unused usings from Program

### DIFF
--- a/test/ScaffoldingTester/ConsoleApp/Program.cs
+++ b/test/ScaffoldingTester/ConsoleApp/Program.cs
@@ -1,7 +1,5 @@
 ﻿using ConsoleApp.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
-using System;
 using System.Linq;
 
 namespace ConsoleApp


### PR DESCRIPTION
No behavioral effect
dotnet format removed two unused usings:
 - Microsoft.Extensions.Options
 - System