### PR TITLE
fix(dacpac): normalize escaped apostrophes in MS_Description values

### DIFF
--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -312,7 +312,20 @@ GO
             Assert.IsTrue(bin.ForeignKeys.Any(fk => fk.Columns.Count == 2));
         }
 
-        
+        [TestCase(null, null)]
+        [TestCase("N'The location''s address'", "The location's address")]
+        [TestCase("'The location''s address'", "The location's address")]
+        [TestCase("N'Plain text'", "Plain text")]
+        [TestCase("'Plain text'", "Plain text")]
+        [TestCase("Plain text", "Plain text")]
+        [TestCase("N''''", "'")]
+        public void FixExtendedPropertyValueNormalizesSqlStringLiterals(string input, string expected)
+        {
+            var result = SqlServerDacpacDatabaseModelFactory.FixExtendedPropertyValue(input);
+
+            Assert.AreEqual(expected, result);
+        }
+
         [Test]
         [Ignore("TBD - need to investigate")]
         public void Issue2263SprocWithCte()

--- a/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
+++ b/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
@@ -503,7 +503,7 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
             }
         }
 
-        private static string FixExtendedPropertyValue(string value)
+        public static string FixExtendedPropertyValue(string value)
         {
             if (value == null)
             {
@@ -525,6 +525,8 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
             {
                 value = value.Remove(value.Length - 1, 1);
             }
+
+            value = value.Replace("''", "'", StringComparison.Ordinal);
 
             return value;
         }


### PR DESCRIPTION
  Fixes part of #3361

  Collapse doubled SQL apostrophes in dacpac extended property values
  so MS_Description comments match the live database reverse-engineering
  path and no longer generate duplicate &apos; entities.