### PR TITLE
fix(dacpac): keep explicit default constraint names in scaffolding metadata

### DIFF
--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -314,6 +314,20 @@ GO
 
         
         [Test]
+        public void ExplicitDefaultConstraintNameFromDacpacIsCaptured()
+        {
+            var factory = new SqlServerDacpacDatabaseModelFactory();
+            var options = new DatabaseModelFactoryOptions(null, new List<string>());
+
+            var dbModel = factory.Create(TestPath("AdventureWorks2014.dacpac"), options);
+            var table = dbModel.Tables.Single(t => t.Schema == "dbo" && t.Name == "AWBuildVersion");
+            var column = table.Columns.Single(c => c.Name == "ModifiedDate");
+
+            Assert.IsNotNull(column.DefaultValueSql);
+            Assert.AreEqual("DF_AWBuildVersion_ModifiedDate", column["Relational:DefaultConstraintName"]);
+        }
+
+        [Test]
         [Ignore("TBD - need to investigate")]
         public void Issue2263SprocWithCte()
         {

--- a/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
+++ b/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
@@ -529,6 +529,10 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
             return value;
         }
 
+        private static bool LooksLikeSystemNamedDefaultConstraint(string constraintName)
+            => !string.IsNullOrEmpty(constraintName)
+                && constraintName.StartsWith("DF__", StringComparison.Ordinal);
+
         private static bool IsNumeric(Type type)
         {
             type = UnwrapNullableType(type);
@@ -727,6 +731,15 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
                 if (storeType == "rowversion")
                 {
                     dbColumn["ConcurrencyToken"] = true;
+                }
+
+                if (def?.Name.HasName == true)
+                {
+                    var defaultConstraintName = def.Name.Parts[^1];
+                    if (!LooksLikeSystemNamedDefaultConstraint(defaultConstraintName))
+                    {
+                        dbColumn["Relational:DefaultConstraintName"] = defaultConstraintName;
+                    }
                 }
 
                 var description = model.GetObjects<TSqlExtendedProperty>(DacQueryScopes.UserDefined)


### PR DESCRIPTION
  Fixes part of #3361

  Preserve explicit default constraint names when reverse engineering
  from dacpac files so the scaffolded model matches the live database
  path more closely.

  Ignore system-generated DF__ names and add a fixture-backed
  regression test.