### PR TITLE
fix(dacpac): preserve multiple table triggers

### DIFF
--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -314,6 +314,18 @@ GO
             Assert.IsTrue(bin.ForeignKeys.Any(fk => fk.Columns.Count == 2));
         }
 
+        [Test]
+        public void MultipleTriggersFromDacpacAreCaptured()
+        {
+            var factory = new SqlServerDacpacDatabaseModelFactory();
+            var options = new DatabaseModelFactoryOptions(null, new List<string>());
+
+            var dbModel = factory.Create(TestPath("AdventureWorks2014.dacpac"), options);
+            var table = dbModel.Tables.Single(t => t.Schema == "Production" && t.Name == "WorkOrder");
+
+            Assert.That(table.Triggers.Select(t => t.Name), Is.EquivalentTo(new[] { "iWorkOrder", "uWorkOrder" }));
+        }
+
         [TestCase(null, null)]
         [TestCase("N'The location''s address'", "The location's address")]
         [TestCase("'The location''s address'", "The location's address")]

--- a/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
+++ b/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
@@ -304,9 +304,9 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
         {
             var triggers = table.Triggers.ToList();
 
-            if (triggers.Count != 0)
+            foreach (var trigger in triggers)
             {
-                dbTable.Triggers.Add(new DatabaseTrigger { Name = triggers[0].Name.Parts[1] });
+                dbTable.Triggers.Add(new DatabaseTrigger { Name = trigger.Name.Parts[1] });
             }
         }
 


### PR DESCRIPTION
  Fixes part of #3361

  Capture all table triggers when reverse engineering from dacpac files
  instead of only the first trigger reference.

  Adds a fixture-backed regression test covering a table with multiple
  triggers in the AdventureWorks2014 dacpac.