### PR TITLE
chore: remove unused deps from EfPlayground

### DIFF
--- a/test/EfPlayground/EfPlayground/EfPlayground.csproj
+++ b/test/EfPlayground/EfPlayground/EfPlayground.csproj
@@ -8,11 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-  <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    <PrivateAssets>all</PrivateAssets>
-  </PackageReference>
   <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.HierarchyId" Version="10.0.5" /> 
   </ItemGroup>


### PR DESCRIPTION
The EfPlayground project still builds without these deps so I'm pretty sure we can remove them to save on dep maintenance in the future.