### PR TITLE
fix: #3458 MS_Description attributes for db views

### DIFF
--- a/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
+++ b/src/Core/NUnitTestCore/Dacpac/DacpacTest.cs
@@ -129,6 +129,62 @@ GO
         }
 
         [Fact]
+        public void ViewDescriptionsAreCaptured()
+        {
+            var factory = new SqlServerDacpacDatabaseModelFactory();
+            var options = new DatabaseModelFactoryOptions(null, new List<string>());
+            var dacpacPath = BuildDacpac(
+                """
+                CREATE TABLE [dbo].[Base]
+                (
+                    [Id] int NOT NULL CONSTRAINT [PK_Base] PRIMARY KEY,
+                    [Name] nvarchar(100)
+                )
+                """,
+                """
+                CREATE VIEW [dbo].[ViewWithDescription]
+                AS
+                    SELECT [Id], [Name]
+                    FROM [dbo].[Base]
+                """,
+                """
+                EXEC sp_addextendedproperty
+                    @name = N'MS_Description',
+                    @value = N'View description',
+                    @level0type = N'SCHEMA',
+                    @level0name = N'dbo',
+                    @level1type = N'VIEW',
+                    @level1name = N'ViewWithDescription'
+                """,
+                """
+                EXEC sp_addextendedproperty
+                    @name = N'MS_Description',
+                    @value = N'Column description',
+                    @level0type = N'SCHEMA',
+                    @level0name = N'dbo',
+                    @level1type = N'VIEW',
+                    @level1name = N'ViewWithDescription',
+                    @level2type = N'COLUMN',
+                    @level2name = N'Name'
+                """);
+
+            try
+            {
+                var dbModel = factory.Create(dacpacPath, options);
+                var view = dbModel.Tables.Single(t => t.Schema == "dbo" && t.Name == "ViewWithDescription");
+
+                Assert.Equal("View description", view.Comment);
+
+                var nameColumn = view.Columns.Single(c => c.Name == "Name");
+                Assert.Equal("Column description", nameColumn.Comment);
+            }
+            finally
+            {
+                File.Delete(dacpacPath);
+            }
+        }
+
+        [Fact]
         public void CanEnumerateSelectedTables()
         {
             // Arrange
@@ -549,12 +605,15 @@ GO
             Assert.Equal(new[] { "JobCandidateID", "RANK" }, multipleResultRoutine.Results[1].Select(c => c.Name));
         }
 
-        private static string BuildDacpac(string sql)
+        private static string BuildDacpac(params string[] sqlScripts)
         {
             var path = Path.Combine(Path.GetTempPath(), $"dacpac-test-{Guid.NewGuid():N}.dacpac");
 
             using var model = new TSqlModel(SqlServerVersion.Sql160, new TSqlModelOptions());
-            model.AddObjects(sql);
+            foreach (var sql in sqlScripts)
+            {
+                model.AddObjects(sql);
+            }
 
             DacPackageExtensions.BuildPackage(path, model, new PackageMetadata { Name = "test" });
 

--- a/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
+++ b/src/Nupkg/ErikEJ.EntityFrameworkCore.8.SqlServer.Dacpac/Scaffolding/SqlServerDacpacDatabaseModelFactory.cs
@@ -176,7 +176,16 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
                     Schema = view.Name.Parts[0],
                 };
 
-                GetViewColumns(view, dbView, typeAliases, tableTypes);
+                GetViewColumns(view, dbView, typeAliases, tableTypes, model);
+
+                var description = model.GetObjects<TSqlExtendedProperty>(DacQueryScopes.UserDefined)
+                    .Where(p => p.Name.Parts.Count == 4)
+                    .Where(p => p.Name.Parts[0] == "SqlView")
+                    .Where(p => p.Name.Parts[1] == dbView.Schema)
+                    .Where(p => p.Name.Parts[2] == dbView.Name)
+                    .FirstOrDefault(p => p.Name.Parts[3] == "MS_Description");
+
+                dbView.Comment = FixExtendedPropertyValue(description?.Value);
 
                 dbModel.Tables.Add(dbView);
             }
@@ -311,7 +320,7 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
             }
         }
 
-        private static void GetViewColumns(TSqlView item, DatabaseView dbTable, Dictionary<string, (string StoreType, string TypeName)> typeAliases, IEnumerable<TSqlTableType> tableTypes)
+        private static void GetViewColumns(TSqlView item, DatabaseView dbTable, Dictionary<string, (string StoreType, string TypeName)> typeAliases, IEnumerable<TSqlTableType> tableTypes, TSqlTypedModel model)
         {
             var viewColumns = item.Element.GetChildren(DacQueryScopes.UserDefined);
 
@@ -370,6 +379,16 @@ namespace ErikEJ.EntityFrameworkCore.SqlServer.Scaffolding
                     IsNullable = col.Nullable,
                     StoreType = storeType,
                 };
+
+                var description = model.GetObjects<TSqlExtendedProperty>(DacQueryScopes.UserDefined)
+                    .Where(p => p.Name.Parts.Count == 5)
+                    .Where(p => p.Name.Parts[0] == "SqlColumn")
+                    .Where(p => p.Name.Parts[1] == dbTable.Schema)
+                    .Where(p => p.Name.Parts[2] == dbTable.Name)
+                    .Where(p => p.Name.Parts[3] == dbColumn.Name)
+                    .FirstOrDefault(p => p.Name.Parts[4] == "MS_Description");
+
+                dbColumn.Comment = FixExtendedPropertyValue(description?.Value);
 
                 dbTable.Columns.Add(dbColumn);
             }


### PR DESCRIPTION
Add handling to map MS_Description attributes to Summary comments on views and their columns when reverse engineering a dacpac. Behavior is similar to that of tables.