### PR TITLE
Refactor unnamed column handling in SP model factories

### DIFF
--- a/src/Core/NUnitTestCore/SqlServerRoutineModelFactoryTests.cs
+++ b/src/Core/NUnitTestCore/SqlServerRoutineModelFactoryTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using RevEng.Core.Abstractions;
 using RevEng.Core.Abstractions.Metadata;
 using RevEng.Core.Routines;
@@ -83,6 +84,53 @@ namespace UnitTests
             var result = SqlServerStoredProcedureModelFactory.ShouldTryDefinitionFallback(errorNumber, message);
 
             Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void AddUnnamedColumnErrorsAddsAllUnnamedMessageWhenAllResultColumnsAreUnnamed()
+        {
+            var errors = new List<string>();
+            var module = new Procedure
+            {
+                Schema = "dbo",
+                Name = "StoGetSomeData",
+                UnnamedColumnCount = 2,
+                Results =
+                [
+                    [new ModuleResultElement(), new ModuleResultElement()],
+                ],
+            };
+
+            SqlServerRoutineModelFactory.AddUnnamedColumnErrors(errors, "PROCEDURE", module);
+
+            Assert.Equal(
+            [
+                "PROCEDURE 'dbo.StoGetSomeData' has 2 unnamed columns.",
+                "All result columns are unnamed for PROCEDURE 'dbo.StoGetSomeData'.",
+            ], errors);
+        }
+
+        [Fact]
+        public void AddUnnamedColumnErrorsDoesNotAddAllUnnamedMessageWhenNamedResultColumnsRemain()
+        {
+            var errors = new List<string>();
+            var module = new Procedure
+            {
+                Schema = "dbo",
+                Name = "StoGetSomeData",
+                UnnamedColumnCount = 1,
+                Results =
+                [
+                    [new ModuleResultElement(), new ModuleResultElement()],
+                ],
+            };
+
+            SqlServerRoutineModelFactory.AddUnnamedColumnErrors(errors, "PROCEDURE", module);
+
+            Assert.Equal(
+            [
+                "PROCEDURE 'dbo.StoGetSomeData' has 1 unnamed columns.",
+            ], errors);
         }
     }
 }

--- a/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureModelFactory.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureModelFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -164,12 +164,6 @@ ORDER BY ROUTINE_NAME;";
                 }
             }
 
-            // If the result set only contains un-named columns
-            if (dtResult.Rows.Count == unnamedColumnCount)
-            {
-                throw new InvalidOperationException($"Only un-named result columns in procedure");
-            }
-
             if (unnamedColumnCount > 0)
             {
                 module.UnnamedColumnCount += unnamedColumnCount;
@@ -275,12 +269,6 @@ ORDER BY ROUTINE_NAME;";
                             MaxLength = (int)row["ColumnSize"],
                         });
                     }
-                }
-
-                // If the result set only contains un-named columns
-                if (schemaTable.Rows.Count > 0 && schemaTable.Rows.Count == unnamedColumnCount)
-                {
-                    throw new InvalidOperationException("Only un-named result columns in procedure");
                 }
 
                 if (unnamedColumnCount > 0)

--- a/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureScaffolder.cs
+++ b/src/Core/RevEng.Core.80/Routines/Procedures/SqlServerStoredProcedureScaffolder.cs
@@ -272,9 +272,6 @@ namespace RevEng.Core.Routines.Procedures
                 {
                     returnType = $"List<{returnClass}>";
                 }
-
-                // Do not add nullable annotation to List<T> when nullable references are enabled
-                // The list itself is never null (empty list instead)
             }
 
             returnType = useAsyncCalls ? $"Task<{returnType}>" : returnType;

--- a/src/Core/RevEng.Core.80/Routines/SqlServerRoutineModelFactory.cs
+++ b/src/Core/RevEng.Core.80/Routines/SqlServerRoutineModelFactory.cs
@@ -34,6 +34,24 @@ namespace RevEng.Core.Routines
             return options.ModulesUsingLegacyDiscovery?.Contains($"[{module.Schema}].[{module.Name}]") ?? false;
         }
 
+        internal static void AddUnnamedColumnErrors(List<string> errors, string routineType, Routine module)
+        {
+            if (module.UnnamedColumnCount > 0)
+            {
+                errors.Add($"{routineType} '{module.Schema}.{module.Name}' has {module.UnnamedColumnCount} unnamed columns.");
+
+                if (module.Results.Count > 0)
+                {
+                    var resultElementCount = module.Results.Sum(r => r.Count);
+
+                    if (resultElementCount <= module.UnnamedColumnCount)
+                    {
+                        errors.Add($"All result columns are unnamed for {routineType} '{module.Schema}.{module.Name}'.");
+                    }
+                }
+            }
+        }
+
         protected RoutineModel GetRoutines(string connectionString, ModuleModelFactoryOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
@@ -165,20 +183,7 @@ namespace RevEng.Core.Routines
                                 }
                             }
 
-                            if (module.UnnamedColumnCount > 0)
-                            {
-                                errors.Add($"{RoutineType} '{module.Schema}.{module.Name}' has {module.UnnamedColumnCount} unnamed columns.");
-
-                                if (module.Results.Count > 0)
-                                {
-                                    var resultElementCount = module.Results.Sum(r => r.Count);
-
-                                    if (resultElementCount <= module.UnnamedColumnCount)
-                                    {
-                                        errors.Add($"All result columns are unnamed for {RoutineType} '{module.Schema}.{module.Name}'.");
-                                    }
-                                }
-                            }
+                            AddUnnamedColumnErrors(errors, RoutineType, module);
 
                             if (dupesFound)
                             {

--- a/src/Core/RevEng.Core.80/Routines/SqlServerRoutineModelFactory.cs
+++ b/src/Core/RevEng.Core.80/Routines/SqlServerRoutineModelFactory.cs
@@ -167,7 +167,17 @@ namespace RevEng.Core.Routines
 
                             if (module.UnnamedColumnCount > 0)
                             {
-                                errors.Add($"{RoutineType} '{module.Schema}.{module.Name}' has {module.UnnamedColumnCount} un-named columns.");
+                                errors.Add($"{RoutineType} '{module.Schema}.{module.Name}' has {module.UnnamedColumnCount} unnamed columns.");
+
+                                if (module.Results.Count > 0)
+                                {
+                                    var resultElementCount = module.Results.Sum(r => r.Count);
+
+                                    if (resultElementCount <= module.UnnamedColumnCount)
+                                    {
+                                        errors.Add($"All result columns are unnamed for {RoutineType} '{module.Schema}.{module.Name}'.");
+                                    }
+                                }
                             }
 
                             if (dupesFound)


### PR DESCRIPTION
fixes #3471

Removed exceptions for all unnamed result columns in SqlServerStoredProcedureModelFactory.cs and schema table logic; now only increments UnnamedColumnCount.

Updated SqlServerRoutineModelFactory.cs to add explicit error messages for routines with all unnamed columns and improved error wording.